### PR TITLE
Fix typo in dhcpd.conf.ddns.erb

### DIFF
--- a/templates/dhcpd.conf.ddns.erb
+++ b/templates/dhcpd.conf.ddns.erb
@@ -1,4 +1,4 @@
-<% if @dnsupdatekey ) -%>
+<% if @dnsupdatekey -%>
 # ----------
 # Dynamic DNS Updates
 # ----------


### PR DESCRIPTION
This typo caused the master catalog compile to fail with this error:

```
err: Could not retrieve catalog from remote server: Error 400 on SERVER: compile error
/etc/puppetlabs/puppet/environments/jeff/puppet/modules_ext/dhcp/templates/dhcpd.conf.ddns.erb:1: syntax error, unexpected ')', expecting kTHEN or ':' or '\n' or ';'
_erbout = '';  if @dnsupdatekey )
                                 ^
/etc/puppetlabs/puppet/environments/jeff/puppet/modules_ext/dhcp/templates/dhcpd.conf.ddns.erb:18: syntax error, unexpected kELSE, expecting $end
 else
     ^
warning: Not using cache on failed catalog
err: Could not retrieve catalog; skipping run
```
