### PR TITLE
Update dhcpd.conf to use modern variable lookup

### DIFF
--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -33,7 +33,7 @@ option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
 option fqdn.rcode2            255;
 option pxegrub code 150 = text ;
 
-<% if @pxeserver and @pxefilename then -%>
+<% if @pxeserver && @pxeserver != :undef and @pxefilename && @pxefilename != :undef then -%>
 # PXE Handoff.
 next-server <%= pxeserver %>;
 filename "<%= pxefilename %>";


### PR DESCRIPTION
Without this patch applied dhcp.conf is populated with entries like
this:

```
# ----------
# PXE Handoff
# ----------
next-server undef;
filename "undef";
```
