### PR TITLE
Update manifests per puppet-lint

### DIFF
--- a/manifests/disable.pp
+++ b/manifests/disable.pp
@@ -8,14 +8,14 @@ class dhcp::disable {
   $servicename = $dhcp::params::servicename
 
   package { $packagename:
-    ensure => absent;
+    ensure => absent,
   }
 
   service { $servicename:
-    enable    => false,
     ensure    => stopped,
+    enable    => false,
     hasstatus => true,
-    require   => Package[$packagename];
+    require   => Package[$packagename],
   }
 
 }

--- a/manifests/failover.pp
+++ b/manifests/failover.pp
@@ -1,5 +1,5 @@
 class dhcp::failover (
-  $role                = "primary",
+  $role                = 'primary',
   $address             = $ipaddress,
   $peer_address,
   $port                = '519',
@@ -15,8 +15,8 @@ class dhcp::failover (
   $dhcp_dir = $dhcp::params::dhcp_dir
 
   concat::fragment { 'dhcp-conf-failover':
-      target  => "${dhcp_dir}/dhcpd.conf",
-      content => template("dhcp/dhcpd.conf.failover.erb"),
+    target  => "${dhcp_dir}/dhcpd.conf",
+    content => template('dhcp/dhcpd.conf.failover.erb'),
   }
 
 }

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,8 +1,8 @@
 define dhcp::host (
-    $ip,
-    $mac,
-    $comment=''
-  ) {
+  $ip,
+  $mac,
+  $comment=''
+) {
 
   $host = $name
   include dhcp::params
@@ -10,9 +10,9 @@ define dhcp::host (
   $dhcp_dir = $dhcp::params::dhcp_dir
 
   concat::fragment { "dhcp_host_${name}":
-      target  => "${dhcp_dir}/dhcpd.hosts",
-      content => template("dhcp/dhcpd.host.erb"),
-      order   => 10,
+    target  => "${dhcp_dir}/dhcpd.hosts",
+    content => template('dhcp/dhcpd.host.erb'),
+    order   => 10,
   }
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,16 +1,16 @@
 class dhcp (
-    $dnsdomain,
-    $nameservers,
-    $ntpservers,
-    $interfaces         = undef,
-    $interface          = "NOTSET",
-    $dnsupdatekey       = undef,
-    $pxeserver          = undef,
-    $pxefilename        = undef,
-    $logfacility        = 'local7',
-    $default_lease_time = 3600,
-    $max_lease_time     = 86400,
-    $failover           = ''
+  $dnsdomain,
+  $nameservers,
+  $ntpservers,
+  $interfaces         = undef,
+  $interface          = 'NOTSET',
+  $dnsupdatekey       = undef,
+  $pxeserver          = undef,
+  $pxefilename        = undef,
+  $logfacility        = 'local7',
+  $default_lease_time = 3600,
+  $max_lease_time     = 86400,
+  $failover           = ''
 ) {
 
   include dhcp::params
@@ -22,10 +22,10 @@ class dhcp (
   # Incase people set interface instead of interfaces work around
   # that. If they set both, use interfaces and the user is a unwise
   # and deserves what they get.
-  if $interface != "NOTSET" and $interfaces == undef {
+  if $interface != 'NOTSET' and $interfaces == undef {
     $dhcp_interfaces = [ $interface ]
-  } elsif $interface == "NOTSET" and $interfaces == undef {
-    fail ("You need to set \$interfaces in $module_name")
+  } elsif $interface == 'NOTSET' and $interfaces == undef {
+    fail ("You need to set \$interfaces in ${module_name}")
   } else {
     $dhcp_interfaces = $interfaces
   }
@@ -59,22 +59,22 @@ class dhcp (
   # dhcpd.conf
   concat {  "${dhcp_dir}/dhcpd.conf": }
   concat::fragment { 'dhcp-conf-header':
-      target  => "${dhcp_dir}/dhcpd.conf",
-      content => template("dhcp/dhcpd.conf-header.erb"),
-      order   => 01,
+    target  => "${dhcp_dir}/dhcpd.conf",
+    content => template('dhcp/dhcpd.conf-header.erb'),
+    order   => 01,
   }
   concat::fragment { 'dhcp-conf-ddns':
-      target  => "${dhcp_dir}/dhcpd.conf",
-      content => template("dhcp/dhcpd.conf.ddns.erb"),
+    target  => "${dhcp_dir}/dhcpd.conf",
+    content => template('dhcp/dhcpd.conf.ddns.erb'),
   }
   concat::fragment { 'dhcp-conf-pxe':
-      target  => "${dhcp_dir}/dhcpd.conf",
-      content => template("dhcp/dhcpd.conf.pxe.erb"),
+    target  => "${dhcp_dir}/dhcpd.conf",
+    content => template('dhcp/dhcpd.conf.pxe.erb'),
   }
   concat::fragment { 'dhcp-conf-extra':
-      target  => "${dhcp_dir}/dhcpd.conf",
-      content => template("dhcp/dhcpd.conf-extra.erb"),
-      order   => 99,
+    target  => "${dhcp_dir}/dhcpd.conf",
+    content => template('dhcp/dhcpd.conf-extra.erb'),
+    order   => 99,
   }
 
 
@@ -95,14 +95,13 @@ class dhcp (
   }
 
   service { $servicename:
-    enable    => "true",
-    ensure    => "running",
+    ensure    => running,
+    enable    => true,
     hasstatus => true,
     subscribe => [Concat["${dhcp_dir}/dhcpd.pools"], Concat["${dhcp_dir}/dhcpd.hosts"], File["${dhcp_dir}/dhcpd.conf"]],
-    require   => Package[$packagename];
+    require   => Package[$packagename],
   }
 
   include dhcp::monitor
 
 }
-

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,25 +1,25 @@
 class dhcp::params {
 
-  case $operatingsystem {
+  case $::operatingsystem {
     'debian': {
-      $dhcp_dir    = "/etc/dhcp"
-      $packagename = "isc-dhcp-server"
-      $servicename = "isc-dhcp-server"
+      $dhcp_dir    = '/etc/dhcp'
+      $packagename = 'isc-dhcp-server'
+      $servicename = 'isc-dhcp-server'
     }
     'ubuntu': {
-      $dhcp_dir    = "/etc/dhcp3"
-      $packagename = "isc-dhcp-server"
-      $servicename = "isc-dhcp-server"
+      $dhcp_dir    = '/etc/dhcp3'
+      $packagename = 'isc-dhcp-server'
+      $servicename = 'isc-dhcp-server'
     }
     'darwin': {
-      $dhcp_dir    = "/opt/local/etc/dhcp"
-      $packagename = "dhcp"
-      $servicename = "org.macports.dhcpd"
+      $dhcp_dir    = '/opt/local/etc/dhcp'
+      $packagename = 'dhcp'
+      $servicename = 'org.macports.dhcpd'
     }
     'freebsd': {
-      $dhcp_dir    = "/usr/local/etc"
-      $packagename = "net/isc-dhcp42-server"
-      $servicename = "isc-dhcpd"
+      $dhcp_dir    = '/usr/local/etc'
+      $packagename = 'net/isc-dhcp42-server'
+      $servicename = 'isc-dhcpd'
     }
   }
 

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -1,11 +1,11 @@
 define dhcp::pool (
-    $network,
-    $mask,
-    $range,
-    $gateway,
-    $failover    = '',
-    $options     = '',
-    $parameters  = '',
+  $network,
+  $mask,
+  $range,
+  $gateway,
+  $failover    = '',
+  $options     = '',
+  $parameters  = ''
 ) {
 
   include dhcp::params
@@ -14,7 +14,7 @@ define dhcp::pool (
 
   concat::fragment { "dhcp_pool_${name}":
     target  => "${dhcp_dir}/dhcpd.pools",
-    content => template("dhcp/dhcpd.pool.erb");
+    content => template('dhcp/dhcpd.pool.erb'),
   }
 
 }


### PR DESCRIPTION
- double space.
- single quote when appropriate.
- remove ';' from variables.
- use top scope variables.
