### PR TITLE
Update dhcp module path for Ubuntu precise.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,11 @@ class dhcp::params {
       $servicename = 'isc-dhcp-server'
     }
     'ubuntu': {
-      $dhcp_dir    = '/etc/dhcp3'
+      if versioncmp($::operatingsystemrelease, '12.04') >= 0 {
+        $dhcp_dir    = '/etc/dhcp'
+      } else {
+        $dhcp_dir    = '/etc/dhcp3'
+      }
       $packagename = 'isc-dhcp-server'
       $servicename = 'isc-dhcp-server'
     }


### PR DESCRIPTION
In Ubuntu precise, the dhcp dir is /etc/dhcp for isc-dhcp-server.

The changes have been only tested on precise. and I'm uncertain how far
back this change was put in place since the filelist have not changed:
http://packages.ubuntu.com/natty/amd64/isc-dhcp-server/filelist
http://packages.ubuntu.com/oneiric/amd64/isc-dhcp-server/filelist
http://packages.ubuntu.com/precise/amd64/isc-dhcp-server/filelist
