### PR TITLE
Make the dhcp module more reusable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,20 +2,20 @@ class dhcp (
   $dnsdomain,
   $nameservers,
   $ntpservers,
-  $dhcp_conf_header   = 'INTERNAL_TEMPLATE',
-  $dhcp_conf_ddns     = 'INTERNAL_TEMPLATE',
-  $dhcp_conf_pxe      = 'INTERNAL_TEMPLATE',
-  $dhcp_conf_extra    = 'INTERNAL_TEMPLATE',
+  $dhcp_conf_header    = 'INTERNAL_TEMPLATE',
+  $dhcp_conf_ddns      = 'INTERNAL_TEMPLATE',
+  $dhcp_conf_pxe       = 'INTERNAL_TEMPLATE',
+  $dhcp_conf_extra     = 'INTERNAL_TEMPLATE',
   $dhcp_conf_fragments = {},
-  $interfaces         = undef,
-  $interface          = 'NOTSET',
-  $dnsupdatekey       = undef,
-  $pxeserver          = undef,
-  $pxefilename        = undef,
-  $logfacility        = 'daemon',
-  $default_lease_time = 3600,
-  $max_lease_time     = 86400,
-  $failover           = ''
+  $interfaces          = undef,
+  $interface           = 'NOTSET',
+  $dnsupdatekey        = undef,
+  $pxeserver           = undef,
+  $pxefilename         = undef,
+  $logfacility         = 'daemon',
+  $default_lease_time  = 3600,
+  $max_lease_time      = 86400,
+  $failover            = ''
 ) {
 
   include dhcp::params


### PR DESCRIPTION
Without this patch large portions of the dhcpd.conf are solely under the
control of the dhcp module itself.  This is a problem for 3rd parties
like myself who want to change some of the behavior configured in this
file by these resources.

This patch fixes the problem in a non-breaking way by exposing all of
the configuration file fragments flowing into dhcpd.conf as class
parameters of the main dhcp class.  3rd parties may now override the
header using their own content like so:

```
class { dhcp:
  dhcp_conf_header => template("site/my_dhcpd.conf.header")
}
```
