### PR TITLE
Send the client hostname to be used if unset

### DIFF
--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -1,5 +1,9 @@
 host <%= host %> {
   hardware ethernet   <%= mac %>;
   fixed-address       <%= ip %>;
-  ddns-hostname       "<%= name %>";
+  # Send the client hostname to be used if hostname not set on the client.
+  option host-name    "<%= name %>";
+  # Set the client hostname for the DHCP server DDNS update.
+  # TEST: Does this get the dhcp server to send the hostname?
+  # ddns-hostname       "<%= name %>";
 }


### PR DESCRIPTION
Without this patch the hostname is not being set based on the DHCP
offer.  This is using a relatively stock Debian Squeeze installation.
The hostname has been cleared from /etc/hostname

This patch requires an accompanying change to dhclient on the agent.
The following exit hook will properly set the hostname on Squeeze.

```
# /etc/dhcp/dhclient-exit-hooks.d/hostname
export PATH=/opt/puppet/bin:/usr/bin:/bin:/sbin:/usr/sbin:$PATH
hostname $new_host_name
puppet resource host $(facter fqdn) \
  ensure=present \
  ip=$(facter ipaddress) \
  host_aliases=$(facter hostname)
```
