### PR TITLE
Added Redhat/CentOS package name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,6 @@ class dhcp::params {
       $packagename = 'net/isc-dhcp42-server'
       $servicename = 'isc-dhcpd'
     }
-
     'redhat','fedora','centos': {
       $dhcp_dir    = '/etc/dhcp'
       $packagename = 'dhcp'


### PR DESCRIPTION
- Tested on CentOS6.0

This pull req can go straight in - but related to this.... there is still an issue with running this on freshly installed boxes that haven't had a yum update whereby dhcp will fail because of a conflict of man pages with dhclient.  The problem has existed for years and never been fixed.  The solution is to update dhclient before installing dhcp.... should we try and do this from the dhcp module or leave it out for now?
