### PR TITLE
Remove failover parameter from class dhcp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,8 +14,7 @@ class dhcp (
   $pxefilename         = undef,
   $logfacility         = 'daemon',
   $default_lease_time  = 3600,
-  $max_lease_time      = 86400,
-  $failover            = ''
+  $max_lease_time      = 86400
 ) {
 
   include dhcp::params


### PR DESCRIPTION
This parameter seems not to be used anywhere.
