### PR TITLE
Define class without ntpservers-parameter.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,10 @@
 class dhcp (
   $dnsdomain,
   $nameservers,
-  $ntpservers,
+  $ntpservers          = undef,
   $dhcp_conf_header    = 'INTERNAL_TEMPLATE',
   $dhcp_conf_ddns      = 'INTERNAL_TEMPLATE',
+  $dhcp_conf_ntp      = 'INTERNAL_TEMPLATE',
   $dhcp_conf_pxe       = 'INTERNAL_TEMPLATE',
   $dhcp_conf_extra     = 'INTERNAL_TEMPLATE',
   $dhcp_conf_fragments = {},
@@ -44,6 +45,10 @@ class dhcp (
   $dhcp_conf_header_real = $dhcp_conf_header ? {
     INTERNAL_TEMPLATE => template('dhcp/dhcpd.conf-header.erb'),
     default           => $dhcp_conf_header,
+  }
+  $dhcp_conf_ntp_real = $dhcp_conf_ntp ? {
+    INTERNAL_TEMPLATE => template('dhcp/dhcpd.conf.ntp.erb'),
+    default           => $dhcp_conf_ntp,
   }
   $dhcp_conf_ddns_real = $dhcp_conf_ddns ? {
     INTERNAL_TEMPLATE => template('dhcp/dhcpd.conf.ddns.erb'),
@@ -90,6 +95,11 @@ class dhcp (
     target  => "${dhcp_dir}/dhcpd.conf",
     content => $dhcp_conf_header_real,
     order   => 01,
+  }
+  concat::fragment { 'dhcp-conf-ntp':
+    target  => "${dhcp_dir}/dhcpd.conf",
+    content => $dhcp_conf_ntp_real,
+    order   => 02,
   }
   concat::fragment { 'dhcp-conf-ddns':
     target  => "${dhcp_dir}/dhcpd.conf",

--- a/templates/dhcpd.conf-header.erb
+++ b/templates/dhcpd.conf-header.erb
@@ -12,7 +12,6 @@ log-facility <%= logfacility %>;
 # ----------
 option domain-name "<%= dnsdomain.first %>";
 option domain-name-servers <%= nameservers.join(', ') %>;
-option ntp-servers <%= ntpservers.join(', ') %>;
 option fqdn.no-client-update on;  # set the "O" and "S" flag bits
 option fqdn.rcode2 255;
 option pxegrub code 150 = text;

--- a/templates/dhcpd.conf.ntp.erb
+++ b/templates/dhcpd.conf.ntp.erb
@@ -1,0 +1,7 @@
+# BEGIN NTP Section
+<% if @ntpservers -%>
+option ntp-servers <%= ntpservers.join(', ') %>;
+<% else -%>
+option ntp-servers none;
+<% end -%>
+# END NTP Section


### PR DESCRIPTION
Hello Puppetlabs,

I've added the possibility to define the dhcp-class without a ntpservers-parameter. Since it's not necessary to have it in the dhcp-configuration to get the DHCP-service working.

Hopefully you can pull the changes I've commit.
