### PR TITLE
Make 'range' optional

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -1,8 +1,8 @@
 define dhcp::pool (
   $network,
   $mask,
-  $range,
   $gateway,
+  $range       = '',
   $failover    = '',
   $options     = '',
   $parameters  = ''

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -2,15 +2,19 @@
 # <%= name network mask %>
 #################################
 subnet <%= network %> netmask <%= mask %> {
+<% if range != '' or failover != '' -%>
   pool
   {
 <% if failover != '' -%>
     failover peer "<%= failover %>";
 <% end -%>
+<% if range != '' -%>
 <% range.each do |r| -%>
     range <%= r %>;
 <% end -%>
+<% end -%>
   }
+<% end -%>
 
   option subnet-mask <%= mask %>;
   option routers <%= gateway %>;


### PR DESCRIPTION
Changes allow to not define 'range' parameter, in case if you don't want to assign addresses dynamically.
