### PR TITLE
Allow empty pools

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -1,7 +1,7 @@
 define dhcp::pool (
   $network,
   $mask,
-  $range,
+  $range       = [],
   $gateway,
   $failover    = '',
   $options     = '',

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -2,6 +2,8 @@
 # <%= name network mask %>
 #################################
 subnet <%= network %> netmask <%= mask %> {
+
+<% if range.any? -%>
   pool
   {
 <% if failover != '' -%>
@@ -11,6 +13,7 @@ subnet <%= network %> netmask <%= mask %> {
     range <%= r %>;
 <% end -%>
   }
+<% end -%>
 
   option subnet-mask <%= mask %>;
   option routers <%= gateway %>;


### PR DESCRIPTION
This pull request includes an update to allow a range to be omitted. This is useful for use-cases where the dhcp::host section is used primarily and there should not be any DHCP addresses offered unless it matches a particular host.

```
dhcp::pool{ 'network':
            network => '10.1.168.0',
            mask    => '255.255.255.0',
            gateway => '10.1.168.1',
}

dhcp::host {
      'server1': mac => "00:50:56:b7:60:d5", ip => "10.1.168.206";
}
```
