### PR TITLE
Work around notification problem with concat resources

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,7 +151,9 @@ class dhcp (
   Concat { require => Package[$packagename] }
 
   # dhcpd.conf
-  concat {  "${dhcp_dir}/dhcpd.conf": }
+  concat {  "${dhcp_dir}/dhcpd.conf":
+    notify => Service[$servicename],
+  }
   concat::fragment { 'dhcp-conf-header':
     target  => "${dhcp_dir}/dhcpd.conf",
     content => $dhcp_conf_header_real,
@@ -192,7 +194,9 @@ class dhcp (
   create_resources('concat::fragment', $dhcp_conf_fragments)
 
   # dhcpd.pool
-  concat { "${dhcp_dir}/dhcpd.pools": }
+  concat { "${dhcp_dir}/dhcpd.pools":
+    notify => Service[$servicename],
+  }
   concat::fragment { 'dhcp-pools-header':
     target  => "${dhcp_dir}/dhcpd.pools",
     content => "# DHCP Pools\n",
@@ -200,7 +204,9 @@ class dhcp (
   }
 
   # dhcpd.ignoredsubnets
-  concat { "${dhcp_dir}/dhcpd.ignoredsubnets": }
+  concat { "${dhcp_dir}/dhcpd.ignoredsubnets":
+    notify => Service[$servicename],
+  }
   concat::fragment { 'dhcp-ignoredsubnets-header':
     target  => "${dhcp_dir}/dhcpd.ignoredsubnets",
     content => "# DHCP Subnets (ignored)\n",
@@ -208,7 +214,9 @@ class dhcp (
   }
 
   # dhcpd.hosts
-  concat { "${dhcp_dir}/dhcpd.hosts": }
+  concat { "${dhcp_dir}/dhcpd.hosts":
+    notify => Service[$servicename],
+  }
   concat::fragment { 'dhcp-hosts-header':
     target  => "${dhcp_dir}/dhcpd.hosts",
     content => "# static DHCP hosts\n",
@@ -247,7 +255,6 @@ class dhcp (
     ensure    => $service_ensure,
     enable    => true,
     hasstatus => true,
-    subscribe => [Concat["${dhcp_dir}/dhcpd.pools"], Concat["${dhcp_dir}/dhcpd.hosts"], Concat["${dhcp_dir}/dhcpd.conf"]],
     require   => Package[$packagename],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,12 +148,12 @@ class dhcp (
     default: { }
   }
 
-  Concat { require => Package[$packagename] }
-
-  # dhcpd.conf
-  concat {  "${dhcp_dir}/dhcpd.conf":
+  Concat { require => Package[$packagename],
     notify => Service[$servicename],
   }
+
+  # dhcpd.conf
+  concat {  "${dhcp_dir}/dhcpd.conf": }
   concat::fragment { 'dhcp-conf-header':
     target  => "${dhcp_dir}/dhcpd.conf",
     content => $dhcp_conf_header_real,
@@ -194,9 +194,7 @@ class dhcp (
   create_resources('concat::fragment', $dhcp_conf_fragments)
 
   # dhcpd.pool
-  concat { "${dhcp_dir}/dhcpd.pools":
-    notify => Service[$servicename],
-  }
+  concat { "${dhcp_dir}/dhcpd.pools": }
   concat::fragment { 'dhcp-pools-header':
     target  => "${dhcp_dir}/dhcpd.pools",
     content => "# DHCP Pools\n",
@@ -204,9 +202,7 @@ class dhcp (
   }
 
   # dhcpd.ignoredsubnets
-  concat { "${dhcp_dir}/dhcpd.ignoredsubnets":
-    notify => Service[$servicename],
-  }
+  concat { "${dhcp_dir}/dhcpd.ignoredsubnets": }
   concat::fragment { 'dhcp-ignoredsubnets-header':
     target  => "${dhcp_dir}/dhcpd.ignoredsubnets",
     content => "# DHCP Subnets (ignored)\n",
@@ -214,9 +210,7 @@ class dhcp (
   }
 
   # dhcpd.hosts
-  concat { "${dhcp_dir}/dhcpd.hosts":
-    notify => Service[$servicename],
-  }
+  concat { "${dhcp_dir}/dhcpd.hosts": }
   concat::fragment { 'dhcp-hosts-header':
     target  => "${dhcp_dir}/dhcpd.hosts",
     content => "# static DHCP hosts\n",


### PR DESCRIPTION
The service subscribing to concat resources does somehow not retain
execution order. But having the resources notify the service does.

When freshly setting up dhcpd on Debian jessie with their current puppet 3.7.2-4 and puppetlabs-concat 2.0.1-2 package I get:

    root@node1:~# rm -f /etc/dhcp/dhcpd.{hosts,pools,conf}
    root@node1:~# systemctl stop isc-dhcp-server
    root@node1:~# puppet agent -t 
    Notice: /Stage[main]/Dhcp/Concat[/etc/dhcp/dhcpd.conf]/File[/etc/dhcp/dhcpd.conf]/ensure: defined content as '{md5}cd59a406bb9a5f11d2f2f775e713c6f2'
    Notice: /Stage[main]/Dhcp/Concat[/etc/dhcp/dhcpd.pools]/File[/etc/dhcp/dhcpd.pools]/ensure: defined content as '{md5}6560f465d270d816d0afd202343f2bee'
    Error: Could not start Service[isc-dhcp-server]: Execution of '/usr/sbin/service isc-dhcp-server start' returned 1: Job for isc-dhcp-server.service failed. See 'systemctl status isc-dhcp-server.service' and 'journalctl -xn' for details.
    Wrapped exception:
    Execution of '/usr/sbin/service isc-dhcp-server start' returned 1: Job for isc-dhcp-server.service failed. See 'systemctl status isc-dhcp-server.service' and 'journalctl -xn' for details.
    Error: /Stage[main]/Dhcp/Service[isc-dhcp-server]/ensure: change from stopped to running failed: Could not start Service[isc-dhcp-server]: Execution of '/usr/sbin/service isc-dhcp-server start' returned 1: Job for isc-dhcp-server.service failed. See 'systemctl status isc-dhcp-server.service' and 'journalctl -xn' for details.
    Notice: /Stage[main]/Dhcp/Concat[/etc/dhcp/dhcpd.hosts]/File[/etc/dhcp/dhcpd.hosts]/ensure: defined content as '{md5}8921fbc9b1072088e1fc3e0e72e577f7'

Puppet tries to start the service before dhcpd.hosts included by dhcpd.conf is created. With this change it works as expected:

    root@node1:~# rm -f /etc/dhcp/dhcpd.{hosts,pools,conf}
    root@node1:~# systemctl stop isc-dhcp-server
    root@node1:~# puppet agent -t
    Notice: /Stage[main]/Dhcp/Concat[/etc/dhcp/dhcpd.conf]/File[/etc/dhcp/dhcpd.conf]/ensure: defined content as '{md5}cd59a406bb9a5f11d2f2f775e713c6f2'
    Notice: /Stage[main]/Dhcp/Concat[/etc/dhcp/dhcpd.pools]/File[/etc/dhcp/dhcpd.pools]/ensure: defined content as '{md5}54f13af7eeb9b2956f0d8a4f41f985c2'
    Notice: /Stage[main]/Dhcp/Concat[/etc/dhcp/dhcpd.hosts]/File[/etc/dhcp/dhcpd.hosts]/ensure: defined content as '{md5}93cf3ec90f4116070bf6f34c7a237533'
    Notice: /Stage[main]/Dhcp/Service[isc-dhcp-server]/ensure: ensure changed 'stopped' to 'running'
    Info: /Stage[main]/Dhcp/Service[isc-dhcp-server]: Unscheduling refresh on Service[isc-dhcp-server]

I have no actual idea what's happening here and why it works one way but not the other. I can only guess it has something to do with the way puppetlabs/concat works internally.