### PR TITLE
Add optional "comment" field to host template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ requests forwarded by switches etc.
 Create host reservations.
 
     dhcp::host { 'server1':
+      comment => 'Optional descriptive comment',
       mac => '00:50:56:00:00:01',
       ip  => '10.0.1.51',
     }

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -25,6 +25,7 @@ describe 'dhcp::host', :type => :define do
     content = subject.resource('concat::fragment', "dhcp_host_#{title}").send(:parameters)[:content]
     expected_lines = [
       "host #{title} {",
+      "  # test_comment",
       "  hardware ethernet   #{params['mac']};",
       "  fixed-address       #{params['ip']};",
       "  ddns-hostname       \"#{title}\";",

--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -1,4 +1,7 @@
 host <%= @host %> {
+<% if not @comment.empty? -%>
+  # <%= @comment %>
+<% end -%>
   hardware ethernet   <%= @mac.upcase %>;
   fixed-address       <%= @ip %>;
   ddns-hostname       "<%= @name %>";


### PR DESCRIPTION
The "comment" parameter is already supported by the dhcp::host class,
but the value is not passed through to the dhcp.host.erb  template.

If $comment parameter is not empty, add a line with a leading "#" and the comment to the host reservation entry.

Also add "comment =>" to the example host entry in README.md