### PR TITLE
Enable the failover option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Installs and manages a DHCP server.
 * Host reservations
 * Secure dynamic DNS updates when combined with Bind
 * Can create a dummy (ignored) subnet so that the server can be used only as a helper-address target
+* Supports failover, A single pair of servers, you can enable multiple pools 
 
 ## Usage
 Define the server and the zones it will be responsible for.
@@ -37,6 +38,7 @@ Define the pool attributes
       gateway => '10.0.1.1',
     }
 
+
 ### dhcp::ignoredsubnet
 Define a subnet that will be ignored - useful for making the DHCP server only respond to
 requests forwarded by switches etc.
@@ -55,6 +57,37 @@ Create host reservations.
       ip  => '10.0.1.51',
     }
 
+### dhcp::failover
+First setup the failover attributes for the primary and secondary servers
+
+    dhcp::failover{ 'dhcp-failover':
+      role         => 'primary',
+      peer_address => '10.0.1.50',
+      port         => '519',
+      peer_port    => '519',
+    }
+
+    dhcp::failover{ 'dhcp-failover':
+      role         => 'secondary',
+      peer_address => '10.0.1.51',
+      port         => '519',
+      peer_port    => '519',
+    }
+
+
+Enable the failover attribute for a pool        
+
+    dhcp::pool{ 'ops.dc1.example.net':
+      network  => '10.0.1.0',
+      mask     => '255.255.255.0',
+      range    => ['10.0.1.100', '10.0.1.200'],
+      gateway  => '10.0.1.1',
+      failover => 'dhcp-failover',
+    }
+
+This module does not configure the DHCP failover ports in the firewall.
+For more information se [isc.org](https://kb.isc.org/article/AA-00502/0/A-Basic-Guide-to-Configuring-DHCP-Failover.html).
+
 ### parameters
 Parameters are available to configure pxe or ipxe
 
@@ -66,6 +99,7 @@ For more information see [ipxe.org](http://ipxe.org/howto/chainloading).
       ipxe_bootstrap => 'bootstrap.kpxe',
       pxeserver      => '10.0.1.50',
     }
+
 
 ## Contributors
 Zach Leslie <zach.leslie@gmail.com>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class dhcp (
   $dhcp_conf_ntp       = 'INTERNAL_TEMPLATE',
   $dhcp_conf_pxe       = 'INTERNAL_TEMPLATE',
   $dhcp_conf_extra     = 'INTERNAL_TEMPLATE',
+  $dhcp_conf_failover  = 'INTERNAL_TEMPLATE',
   $dhcp_conf_fragments = {},
   $interfaces          = undef,
   $interface           = 'NOTSET',
@@ -25,6 +26,15 @@ class dhcp (
   $globaloptions       = '',
   $omapi_port          = undef,
   $extra_config        = '',
+  $peer_address        = undef,
+  $role                = undef,
+  $port                = undef,
+  $max_response_delay  = undef,
+  $max_unacked_updates = undef,
+  $mclt                = undef,
+  $load_split          = undef,
+  $load_balance        = undef,
+  $omapi_key           = undef,
 ) {
 
   if $dnsdomain == undef {
@@ -55,6 +65,7 @@ class dhcp (
 
   include dhcp::params
   include dhcp::monitor
+  include dhcp::failover
 
   $dhcp_dir         = $dhcp::params::dhcp_dir
   $packagename      = $dhcp::params::packagename
@@ -105,6 +116,10 @@ class dhcp (
   $dhcp_conf_extra_real = $dhcp_conf_extra ? {
     'INTERNAL_TEMPLATE' => template('dhcp/dhcpd.conf-extra.erb'),
     default             => $dhcp_conf_extra,
+  }
+  $dhcp_conf_failover_real = $dhcp_conf_failover ? {
+    'INTERNAL_TEMPLATE' => template('dhcp/dhcpd.conf.failover.erb'),
+    default             => $dhcp_conf_failover,
   }
 
   package { $packagename:

--- a/spec/defines/failover_spec.rb
+++ b/spec/defines/failover_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'dhcp::pool', :type => :define do
+  let :title do
+    'test_pool'
+  end
+  let(:facts) do
+    {
+      :concat_basedir => '/dne',
+      :osfamily => 'RedHat',
+    }
+  end
+
+  let :default_params do
+    {
+      'gateway' => '1.1.1.1',
+      'mask' => '255.255.255.0',
+      'network' => '1.1.1.0',
+      'range' => ['1.1.1.100', '1.1.1.110'],
+    }
+  end
+
+  let :params do
+    default_params
+  end
+
+  it { should contain_concat__fragment("dhcp_pool_#{title}") }
+  it { should_not contain_concat__fragment('failover peer "dhcp-failover"') }
+
+  context 'failover' do
+    let :params do
+      default_params.merge({
+        :failover => 'failover',
+      })
+    end
+
+    it { should contain_concat__fragment('failover peer "dhcp-failover"') }
+
+  end
+
+end


### PR DESCRIPTION
I was unable to run all of the specs on my local machine. I believe that the changes are good, but an extra test run would not hurt.

Is there some reason that the specs look at and require actual parameters on the running machine. It prevents the ability to test on a machine that is not configured as a puppet managed DHCP server.

It may be that there is no other way to stub the results properly but it makes the test feel very brittle and fragile. 