### PR TITLE
WIP: Refactor

### DIFF
--- a/manifests/failover.pp
+++ b/manifests/failover.pp
@@ -11,11 +11,13 @@ class dhcp::failover (
   $load_split           = '128',
   $load_balance         = '3',
   $omapi_key            = '',
-  $dhcp_dir             = $dhcp::params::dhcp_dir,
-) inherits dhcp::params {
+) {
+  if ! defined(Class['dhcp']) {
+    fail('You must include the dhcp base class before using ::dhcp::failover')
+  }
 
   concat::fragment { 'dhcp-conf-failover':
-    target  => "${dhcp_dir}/dhcpd.conf",
+    target  => "${::dhcp::dhcp_dir}/dhcpd.conf",
     content => template('dhcp/dhcpd.conf.failover.erb'),
   }
 }

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -4,19 +4,17 @@ define dhcp::host (
   $ip,
   $mac,
   $options = {},
-  $comment=''
+  $comment = '',
+  $host    = $name,
 ) {
+  if ! defined(Class['dhcp']) {
+    fail('You must include the dhcp base class before using any dhcp defined resources')
+  }
 
   validate_hash($options)
 
-  $host = $name
-
-  include ::dhcp::params
-
-  $dhcp_dir = $dhcp::params::dhcp_dir
-
   concat::fragment { "dhcp_host_${name}":
-    target  => "${dhcp_dir}/dhcpd.hosts",
+    target  => "${::dhcp::dhcp_dir}/dhcpd.hosts",
     content => template('dhcp/dhcpd.host.erb'),
     order   => '10',
   }

--- a/manifests/ignoredsubnet.pp
+++ b/manifests/ignoredsubnet.pp
@@ -2,15 +2,13 @@ define dhcp::ignoredsubnet (
   $network,
   $mask,
 ) {
-
-  include ::dhcp::params
-
-  $dhcp_dir = $dhcp::params::dhcp_dir
-
-  concat::fragment { "dhcp_ignoredsubnet_${name}":
-    target  => "${dhcp_dir}/dhcpd.ignoredsubnets",
-    content => template('dhcp/dhcpd.ignoredsubnet.erb'),
+  if ! defined(Class['dhcp']) {
+    fail('You must include the dhcp base class before using any dhcp defined resources')
   }
 
+  concat::fragment { "dhcp_ignoredsubnet_${name}":
+    target  => "${::dhcp::dhcp_dir}/dhcpd.ignoredsubnets",
+    content => template('dhcp/dhcpd.ignoredsubnet.erb'),
+  }
 }
 

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -13,13 +13,12 @@ define dhcp::pool (
   $domain_name = '',
   $ignore_unknown = undef,
 ) {
-
-  include ::dhcp::params
-
-  $dhcp_dir = $dhcp::params::dhcp_dir
+  if ! defined(Class['dhcp']) {
+    fail('You must include the dhcp base class before using any dhcp defined resources')
+  }
 
   concat::fragment { "dhcp_pool_${name}":
-    target  => "${dhcp_dir}/dhcpd.pools",
+    target  => "${::dhcp::dhcp_dir}/dhcpd.pools",
     content => template('dhcp/dhcpd.pool.erb'),
   }
 }

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -168,7 +168,7 @@ describe 'dhcp', type: :class do
       default_params.merge(interface: 'eth0')
     end
     it { is_expected.to compile.with_all_deps }
-    it { should contain_package('dhcp') \
+    it { is_expected.to contain_package('dhcp') \
       .with_provider('macports')
     }
     ['/opt/local/etc/dhcp/dhcpd.hosts', '/opt/local/etc/dhcp/dhcpd.conf', '/opt/local/etc/dhcp/dhcpd.ignoredsubnets', '/opt/local/etc/dhcp/dhcpd.pools'].each do |file|

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -1,15 +1,6 @@
 require 'spec_helper'
 
 describe 'dhcp::host', type: :define do
-  let :title do
-    'test_host'
-  end
-  let(:facts) do
-    {
-      concat_basedir: '/dne',
-      osfamily: 'RedHat',
-    }
-  end
   let :default_params do
     {
       'ip'      => '1.2.3.4',
@@ -17,44 +8,66 @@ describe 'dhcp::host', type: :define do
       'comment' => 'test_comment'
     }
   end
-  let(:params) { default_params }
-
-  it { should contain_concat__fragment("dhcp_host_#{title}") }
-
-  it 'creates a host declaration' do
-    content = catalogue.resource('concat::fragment', "dhcp_host_#{title}").send(:parameters)[:content]
-    expected_lines = [
-      "host #{title} {",
-      "  hardware ethernet   #{params['mac']};",
-      "  fixed-address       #{params['ip']};",
-      "  ddns-hostname       \"#{title}\";",
-      '}',
-    ]
-    expect(content.split("\n")).to eq(expected_lines)
-  end
-
-  context 'when options defined' do
-    let(:params) do
-      default_params.merge(
-        options: {
-          'vendor-encapsulated-options' => '01:04:31:41:50:43',
-          'domain-name-servers'         => '10.0.0.1',
-        }
-      )
+  context 'when ::dhcp class is included first' do
+    let :title do
+      'test_host'
     end
+    let(:pre_condition) { 'class {"::dhcp": interface => "eth0"}' }
+    let(:facts) do
+      {
+        concat_basedir: '/dne',
+        osfamily: 'RedHat',
+      }
+    end
+    let(:params) { default_params }
 
-    it 'creates a host declaration with options' do
+    it { is_expected.to contain_concat__fragment("dhcp_host_#{title}") }
+
+    it 'creates a host declaration' do
       content = catalogue.resource('concat::fragment', "dhcp_host_#{title}").send(:parameters)[:content]
       expected_lines = [
         "host #{title} {",
         "  hardware ethernet   #{params['mac']};",
         "  fixed-address       #{params['ip']};",
         "  ddns-hostname       \"#{title}\";",
-        '  option domain-name-servers 10.0.0.1;',
-        '  option vendor-encapsulated-options 01:04:31:41:50:43;',
         '}',
       ]
       expect(content.split("\n")).to eq(expected_lines)
+    end
+
+    context 'when options defined' do
+      let(:params) do
+        default_params.merge(
+          options: {
+            'vendor-encapsulated-options' => '01:04:31:41:50:43',
+            'domain-name-servers'         => '10.0.0.1',
+          }
+        )
+      end
+
+      it 'creates a host declaration with options' do
+        content = catalogue.resource('concat::fragment', "dhcp_host_#{title}").send(:parameters)[:content]
+        expected_lines = [
+          "host #{title} {",
+          "  hardware ethernet   #{params['mac']};",
+          "  fixed-address       #{params['ip']};",
+          "  ddns-hostname       \"#{title}\";",
+          '  option domain-name-servers 10.0.0.1;',
+          '  option vendor-encapsulated-options 01:04:31:41:50:43;',
+          '}',
+        ]
+        expect(content.split("\n")).to eq(expected_lines)
+      end
+    end
+  end
+  context 'when ::dhcp class isn\'t included' do
+    let :title do
+      'test_host'
+    end
+    let(:params) { default_params }
+    it 'raises an error' do
+      expect { expect(subject).to contain_dhcp__host('test_host') }
+        .to raise_error Puppet::Error, /You must include the dhcp base class before using any dhcp defined resources/
     end
   end
 end

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -4,6 +4,7 @@ describe 'dhcp::pool', type: :define do
   let :title do
     'test_pool'
   end
+  let(:pre_condition) { 'class {"::dhcp": interface => "eth0"}' }
   let(:facts) do
     {
       concat_basedir: '/dne',
@@ -19,5 +20,5 @@ describe 'dhcp::pool', type: :define do
     }
   end
 
-  it { should contain_concat__fragment("dhcp_pool_#{title}") }
+  it { is_expected.to contain_concat__fragment("dhcp_pool_#{title}") }
 end


### PR DESCRIPTION
Avoid inheriting from params.pp in classes that already require the base
class to have been included.