### PR TITLE
Use ISC default for default_lease_time

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class dhcp (
   $ipxe_filename        = undef,
   $ipxe_bootstrap       = undef,
   $logfacility          = 'daemon',
-  $default_lease_time   = 3600,
+  $default_lease_time   = 43200,
   $max_lease_time       = 86400,
   $service_ensure       = running,
   $globaloptions        = '',

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -10,7 +10,7 @@ describe 'dhcp', type: :class do
       'dhcp_conf_extra'     => 'INTERNAL_TEMPLATE',
       'dhcp_conf_fragments' => {},
       'logfacility'         => 'daemon',
-      'default_lease_time'  => '3600',
+      'default_lease_time'  => '43200',
       'max_lease_time'      => '86400'
     }
   end


### PR DESCRIPTION
per [dhcp.conf(5)](http://manpages.ubuntu.com/manpages/xenial/man5/dhcpd.conf.5.html), and from https://github.com/theforeman/puppet-dhcp/commit/411bb90462129ca572b07e43481564acc9020e1f.