### PR TITLE
Add parameter validation to dhcp::host

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -7,6 +7,7 @@ define dhcp::host (
   $comment=''
 ) {
 
+  validate_string($ip, $mac, $comment)
   validate_hash($options)
 
   $host = $name


### PR DESCRIPTION
If a non-string gets through to the template, [bad things](https://github.com/voxpupuli/puppet-dhcp/issues/109) happen.  Nicer to catch it in the manifest.