### PR TITLE
Allow for dhcp host to be ignored

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -4,10 +4,12 @@ define dhcp::host (
   $ip,
   $mac,
   $options = {},
-  $comment=''
+  $comment='',
+  $ignored = false,
 ) {
 
   validate_hash($options)
+  validate_bool($ignored)
 
   $host = $name
 

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -59,4 +59,26 @@ describe 'dhcp::host', type: :define do
       expect(content.split("\n")).to eq(expected_lines)
     end
   end
+
+  context 'when ignored defined' do
+    let(:params) do
+      default_params.merge(
+        'ignored' => true
+      )
+    end
+
+    it 'creates a host declaration with ignore booting' do
+      content = catalogue.resource('concat::fragment', "dhcp_host_#{title}").send(:parameters)[:content]
+      expected_lines = [
+        "host #{title} {",
+        '  # test_comment',
+        "  hardware ethernet   #{params['mac']};",
+        "  fixed-address       #{params['ip']};",
+        "  ddns-hostname       \"#{title}\";",
+        '  ignore              booting;',
+        '}'
+      ]
+      expect(content.split("\n")).to eq(expected_lines)
+    end
+  end
 end

--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -5,6 +5,9 @@ host <%= @host %> {
   hardware ethernet   <%= @mac.upcase %>;
   fixed-address       <%= @ip %>;
   ddns-hostname       "<%= @name %>";
+<% if @ignored -%>
+  ignore              booting;
+<% end -%>
 <% if not @options.empty? -%>
 <% @options.keys.sort.each do |option| -%>
   option <%= option %> <%= @options[option] %>;


### PR DESCRIPTION
This allows for a dhcp host to be ignored by the dhcp server.  Used for
when the host should be handled by another dhcp server in the same
subnet.