### PR TITLE
Document the define in manifests/ignoredsubnet.pp

### DIFF
--- a/manifests/ignoredsubnet.pp
+++ b/manifests/ignoredsubnet.pp
@@ -1,3 +1,5 @@
+# == Define: dhcp::ignoredsubnet
+#
 define dhcp::ignoredsubnet (
   $network,
   $mask,


### PR DESCRIPTION
Add define documentation in manifests/ignoresubnet.pp so that it passes puppet-lint without a warning.