### PR TITLE
deny dynamic bootp clients if failover is set

### DIFF
--- a/spec/defines/pool6_spec.rb
+++ b/spec/defines/pool6_spec.rb
@@ -18,5 +18,5 @@ describe 'dhcp::pool6', type: :define do
     }
   end
 
-  it { should contain_concat__fragment("dhcp_pool_#{title}") }
+  it { is_expected.to contain_concat__fragment("dhcp_pool_#{title}") }
 end

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -7,6 +7,7 @@ subnet <%= @network %> netmask <%= @mask %> {
   {
 <% if @failover != '' -%>
     failover peer "<%= @failover %>";
+    deny dynamic bootp clients;
 <% end -%>
 <% if @ignore_unknown == true -%>
     ignore unknown-clients ;

--- a/templates/dhcpd.pool6.erb
+++ b/templates/dhcpd.pool6.erb
@@ -7,6 +7,7 @@ subnet6 <%= @network %>/<%= @prefix %> {
   {
 <% if @failover != '' -%>
     failover peer "<%= @failover %>";
+    deny dynamic bootp clients;
 <% end -%>
 <% if @ignore_unknown == true -%>
     ignore unknown-clients ;


### PR DESCRIPTION
According to dhcpd.conf man page:
> Dynamic BOOTP leases are not compatible with failover, and, as such,
> you need to disallow BOOTP in pools that you are using failover for.

[https://linux.die.net/man/5/dhcpd.conf](https://linux.die.net/man/5/dhcpd.conf) (Chapter: Configuring Failover)