### PR TITLE
Support SmartOS

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,15 @@ class dhcp::params {
       $servicename      = ['dhcpd4.service']
       $package_provider = 'pacman'
     }
+    'Solaris': {
+      if ( $::operatingsystem != 'SmartOS' ) {
+        fail('Only SmartOS variant of Solaris is supported.')
+      }
+      $dhcp_dir         = '/opt/local/etc/dhcp'
+      $packagename      = 'isc-dhcpd'
+      $servicename      = 'isc-dhcpd'
+      $package_provider = undef
+    }
     default: {
       fail('dhcp is supported on the following OS\'s: Debian, Ubuntu, Darwin, FreeBSD, RedHat, Fedora, and CentOS.')
     }


### PR DESCRIPTION
Add support for [Joyent SmartOS](https://www.joyent.com/smartos)

Functional on SmartOS base-64 15.4.1-lts