### PR TITLE
Set puppet min version_requirement to 3.8.7 + deps

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,16 +5,16 @@
   "summary": "Manage the ISC dhcp daemon",
   "license": "Apache-2.0",
   "source": "https://github.com/voxpupuli/puppetlabs-dhcp",
-  "project_page": "https://github.com/voxpupuli/puppetlabs-dhcp",
-  "issues_url": "https://github.com/voxpupuli/puppetlabs-dhcp/issues",
+  "project_page": "https://github.com/voxpupuli/puppet-dhcp",
+  "issues_url": "https://github.com/voxpupuli/puppet-dhcp/issues",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.1.0 < 3.0.0"
+      "version_requirement": ">= 1.2.5 < 3.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -49,6 +49,12 @@
     },
     {
       "operatingsystem": "Archlinux"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">=3.8.7 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet 3 versions