### PR TITLE
migrate to puppet4 datatypes

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,16 +1,12 @@
 # == Define: dhcp::host
 #
 define dhcp::host (
-  $ip,
-  $mac,
-  $options = {},
-  $comment='',
-  $ignored = false,
+  Stdlib::Compat::Ip_address $ip,
+  String $mac,
+  Hash $options     = {},
+  String $comment   ='',
+  Boolean $ignored  = false,
 ) {
-
-  validate_string($ip, $mac, $comment)
-  validate_hash($options)
-  validate_bool($ignored)
 
   $host = $name
 

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -1,24 +1,20 @@
 # == Define: dhcp::pool
 #
 define dhcp::pool (
-  $network,
-  $mask,
-  $gateway          = '',
-  $range            = '',
-  $failover         = '',
-  $options          = '',
-  $parameters       = '',
-  $nameservers      = undef,
-  $nameservers_ipv6 = undef,
-  $pxeserver        = undef,
-  $mtu              = undef,
-  $domain_name      = '',
-  $ignore_unknown   = undef,
+  Stdlib::Compat::Ipv4 $network,
+  Stdlib::Compat::Ipv4 $mask,
+  $gateway                                  = '',
+  $range                                    = '',
+  $failover                                 = '',
+  $options                                  = '',
+  $parameters                               = '',
+  Optional[Array[String]] $nameservers      = undef,
+  Optional[Array[String]] $nameservers_ipv6 = undef,
+  Optional[String] $pxeserver               = undef,
+  Optional[Integer] $mtu                    = undef,
+  String $domain_name                       = '',
+  $ignore_unknown                           = undef,
 ) {
-  if $mtu {
-    validate_integer($mtu)
-  }
-
   include ::dhcp::params
 
   $dhcp_dir = $dhcp::params::dhcp_dir

--- a/manifests/pool6.pp
+++ b/manifests/pool6.pp
@@ -1,24 +1,23 @@
 # == Define: dhcp::pool6
 #
 define dhcp::pool6 (
-  $network,
-  $prefix,
-  $range            = '',
-  $range_temp       = '',
-  $failover         = '',
-  $options          = '',
-  $parameters       = '',
-  $nameservers      = undef,
-  $nameservers_ipv6 = undef,
-  $pxeserver        = undef,
-  $mtu              = undef,
-  $domain_name      = '',
-  $ignore_unknown   = undef,
+  # the ipv6 regex is currently wrong so we can't use it here
+  # https://github.com/puppetlabs/puppetlabs-stdlib/pull/731
+  # Stdlib::Compat::Ipv6 $network,
+  String $network,
+  Integer $prefix,
+  String $range                             = '',
+  String $range_temp                        = '',
+  String $failover                          = '',
+  String $options                           = '',
+  String $parameters                        = '',
+  Optional[Array[String]] $nameservers      = undef,
+  Optional[Array[String]] $nameservers_ipv6 = undef,
+  Optional[String] $pxeserver               = undef,
+  Optional[Integer] $mtu                    = undef,
+  String $domain_name                       = '',
+  $ignore_unknown                           = undef,
 ) {
-  if $mtu {
-    validate_integer($mtu)
-  }
-
   include ::dhcp::params
 
   $dhcp_dir = $dhcp::params::dhcp_dir

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 5.0.0"
     },
     {
       "name": "puppetlabs/concat",

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -11,8 +11,8 @@ describe 'dhcp', type: :class do
       'dhcp_conf_extra'     => 'INTERNAL_TEMPLATE',
       'dhcp_conf_fragments' => {},
       'logfacility'         => 'daemon',
-      'default_lease_time'  => '43200',
-      'max_lease_time'      => '86400'
+      'default_lease_time'  => 43_200,
+      'max_lease_time'      => 86_400
     }
   end
 

--- a/spec/defines/pool6_spec.rb
+++ b/spec/defines/pool6_spec.rb
@@ -13,7 +13,7 @@ describe 'dhcp::pool6', type: :define do
   let :params do
     {
       'network'  => '2001:db8::',
-      'prefix'   => '64',
+      'prefix'   => 64,
       'range'    => '2001:db8::100 2001:db8::110'
     }
   end


### PR DESCRIPTION
the goal is to get rid of validate_* functions. Bumping stdlib is
required to get the new datatypes.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
