### PR TITLE
Add flag to manage dhcp service

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The following is the list of all parameters available for this class.
 | `ldap_server`          | String    | `'localhost'`                     |
 | `ldap_username`        | String    | `'cn=root, dc=example, dc=com'`   |
 | `logfacility`          | String    | `'daemon'`                        |
+| `manage_service`       | Boolean   | `true`                       |
 | `max_lease_time`       | Integer   | `86400`                           |
 | `mtu`                  | Integer   | `undef`                           |
 | `nameservers`          | Array     | `[ '8.8.8.8', '8.8.4.4' ]`        |

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -263,10 +263,12 @@ class dhcp (
     }
   }
 
-  service { $servicename:
-    ensure    => $service_ensure,
-    enable    => true,
-    hasstatus => true,
-    require   => Package[$packagename],
+  if $manage_service {
+    service { $servicename:
+      ensure    => $service_ensure,
+      enable    => true,
+      hasstatus => true,
+      require   => Package[$packagename],
+    }
   }
 }


### PR DESCRIPTION
Notify service only if manage_service is set to true

Signed-off-by: Anton Baranov <abaranov@linuxfoundation.org>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
