### PR TITLE
Fix dhcp::ignoredsubnet template

### DIFF
--- a/spec/defines/ignoredsubnet_spec.rb
+++ b/spec/defines/ignoredsubnet_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'dhcp::ignoredsubnet' do
+  let :title do
+    'test_subnet'
+  end
+  let(:facts) do
+    {
+      concat_basedir: '/dne',
+      osfamily: 'RedHat'
+    }
+  end
+  let :default_params do
+    {
+      'network' => '10.1.2.0',
+      'mask' => '255.255.255.0'
+    }
+  end
+  let(:params) { default_params }
+
+  it { is_expected.to contain_concat__fragment("dhcp_ignoredsubnet_#{title}") }
+
+  it 'creates a subnet declaration' do
+    content = catalogue.resource('concat::fragment', "dhcp_ignoredsubnet_#{title}").send(:parameters)[:content]
+    expected_lines = [
+      '#################################',
+      '# test_subnet 10.1.2.0 255.255.255.0',
+      '#################################',
+      'subnet 10.1.2.0 netmask 255.255.255.0 {',
+      '  not authoritative;',
+      '}'
+    ]
+    expect(content.split("\n")).to eq(expected_lines)
+  end
+end

--- a/templates/dhcpd.ignoredsubnet.erb
+++ b/templates/dhcpd.ignoredsubnet.erb
@@ -1,7 +1,7 @@
 #################################
-# <%= name network mask %>
+# <%= @name %> <%= @network %> <%= @mask %>
 #################################
-subnet <%= network %> netmask <%= mask %> {
+subnet <%= @network %> netmask <%= @mask %> {
   not authoritative;
 }
 


### PR DESCRIPTION
It looks like the syntax is incorrect on modern Puppet versions. This
changes it to the modern style and adds a test for it.