### PR TITLE
parameterised ddns-hostnames

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -3,6 +3,7 @@
 define dhcp::host (
   Stdlib::Compat::Ip_address $ip,
   String $mac,
+  String $ddns_hostname = $name,
   Hash $options     = {},
   String $comment   ='',
   Boolean $ignored  = false,

--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -4,7 +4,7 @@ host <%= @host %> {
 <% end -%>
   hardware ethernet   <%= @mac.upcase %>;
   fixed-address       <%= @ip %>;
-  ddns-hostname       "<%= @name %>";
+  ddns-hostname       "<%= @ddns_hostname %>";
 <% if @ignored -%>
   ignore              booting;
 <% end -%>


### PR DESCRIPTION
added parameter for ddns-hostname to allow for multiple static dhcp assignments per ddns hostname. this is necessary for hosts with two interfaces (wifi, ethernet)
