### PR TITLE
dhcpd.conf-extra: move includes below extra_config

### DIFF
--- a/templates/dhcpd.conf-extra.erb
+++ b/templates/dhcpd.conf-extra.erb
@@ -1,11 +1,12 @@
 # BEGIN DHCP Extra configurations
-include "<%= @dhcp_dir %>/dhcpd.pools";
-include "<%= @dhcp_dir %>/dhcpd.hosts";
-include "<%= @dhcp_dir %>/dhcpd.ignoredsubnets";
 <% unless @extra_config.empty? -%>
-# extra_config
 <% @extra_config.each do |config_entry| %>
 <%= config_entry %>  
 <% end -%>
 <% end -%>
 # END DHCP Extra configurations
+# BEGIN Additional configuration files
+include "<%= @dhcp_dir %>/dhcpd.pools";
+include "<%= @dhcp_dir %>/dhcpd.hosts";
+include "<%= @dhcp_dir %>/dhcpd.ignoredsubnets";
+# END Additional configuration files


### PR DESCRIPTION
To use an option space added in extra_config in dhcpd.pools it needs to
be declared before it can be used.