### PR TITLE
Fix notification target

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -183,7 +183,7 @@ class dhcp (
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
-      notify  => Service[$servicename],
+      notify  => $service_notify_real,
       content => template('dhcp/dhcpd.service'),
     }
   } else {


### PR DESCRIPTION
This fixes an error when `manage_service` is false.
Fixes #170.