### PR TITLE
Use match_array for better failure output

### DIFF
--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -249,7 +249,7 @@ describe 'dhcp', type: :class do
             '  key rndc.key;',
             '}'
           ]
-          expect(content.split("\n").reject { |l| l =~ %r{^#|^$} }).to eq(expected_lines)
+          expect(content.split("\n").reject { |l| l =~ %r{^#|^$} }).to match_array(expected_lines)
         end
 
         context 'dnskeyname defined' do
@@ -288,7 +288,7 @@ describe 'dhcp', type: :class do
           'ldap-method dynamic;',
           'ldap-debug-file "/var/log/dhcp-ldap-startup.log";'
         ]
-        expect(content.split("\n").reject { |l| l =~ %r{^#|^$} }).to eq(expected_lines)
+        expect(content.split("\n").reject { |l| l =~ %r{^#|^$} }).to match_array(expected_lines)
       end
     end
     context 'ldap enabled without logfile' do
@@ -310,7 +310,7 @@ describe 'dhcp', type: :class do
           'ldap-base-dn "dc=example, dc=com";',
           'ldap-method dynamic;'
         ]
-        expect(content.split("\n").reject { |l| l =~ %r{^#|^$} }).to eq(expected_lines)
+        expect(content.split("\n").reject { |l| l =~ %r{^#|^$} }).to match_array(expected_lines)
       end
     end
 
@@ -597,7 +597,7 @@ describe 'dhcp', type: :class do
     it do
       content = catalogue.resource('concat::fragment', 'dhcp-conf-pxe').send(:parameters)[:content]
       expected_lines = ['filename "pxelinux.0";', 'next-server 1.2.3.4;']
-      expect(content.split("\n").reject { |l| l =~ %r{^#|^$} }).to eq(expected_lines)
+      expect(content.split("\n").reject { |l| l =~ %r{^#|^$} }).to match_array(expected_lines)
     end
 
     context 'ipxefilename defined' do
@@ -618,7 +618,7 @@ describe 'dhcp', type: :class do
           '      filename "undionly-20140116.kpxe";',
           '}'
         ]
-        expect(content.split("\n").reject { |l| l =~ %r{^#|^$} }).to eq(expected_lines)
+        expect(content.split("\n").reject { |l| l =~ %r{^#|^$} }).to match_array(expected_lines)
       end
     end
   end

--- a/spec/defines/dhcp_class_spec.rb
+++ b/spec/defines/dhcp_class_spec.rb
@@ -24,7 +24,7 @@ describe 'dhcp::dhcp_class', type: :define do
         '  match option vendor-class-identifier;',
         '}'
       ]
-      expect(content.split("\n")).to eq(expected_lines)
+      expect(content.split("\n")).to match_array(expected_lines)
     end
   end
 
@@ -43,7 +43,7 @@ describe 'dhcp::dhcp_class', type: :define do
         '  match option identifier-2;',
         '}'
       ]
-      expect(content.split("\n")).to eq(expected_lines)
+      expect(content.split("\n")).to match_array(expected_lines)
     end
   end
 end

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -33,7 +33,7 @@ describe 'dhcp::host', type: :define do
       "  ddns-hostname       \"#{title}\";",
       '}'
     ]
-    expect(content.split("\n")).to eq(expected_lines)
+    expect(content.split("\n")).to match_array(expected_lines)
   end
 
   context 'when options defined' do
@@ -58,7 +58,7 @@ describe 'dhcp::host', type: :define do
         '  option vendor-encapsulated-options 01:04:31:41:50:43;',
         '}'
       ]
-      expect(content.split("\n")).to eq(expected_lines)
+      expect(content.split("\n")).to match_array(expected_lines)
     end
   end
 
@@ -80,7 +80,7 @@ describe 'dhcp::host', type: :define do
         '  ignore              booting;',
         '}'
       ]
-      expect(content.split("\n")).to eq(expected_lines)
+      expect(content.split("\n")).to match_array(expected_lines)
     end
   end
 end

--- a/spec/defines/ignoredsubnet_spec.rb
+++ b/spec/defines/ignoredsubnet_spec.rb
@@ -31,6 +31,6 @@ describe 'dhcp::ignoredsubnet' do
       '  not authoritative;',
       '}'
     ]
-    expect(content.split("\n")).to eq(expected_lines)
+    expect(content.split("\n")).to match_array(expected_lines)
   end
 end


### PR DESCRIPTION
eq() is very useless on array comparison when you want to debug:

```
expected: ["ddns-updates on;", "ddns-update-style standard;", "update-static-leases on;", "update-optimization ...1.1.1.in-addr.arpa. {", "  primary 1.1.1.1;", "  primary6 1:5ee:bad::c0de;", "  key rndc.key;", "}"]
     got: ["ddns-updates on;", "ddns-update-style standard;", "update-static-leases on;", "update-optimization ...1.1.1.in-addr.arpa. {", "  primary 1.1.1.1;", "  primary6 1:5ee:bad::c0de;", "  key rndc.key;", "}"]
```

match_array will show which elements are missing and extra.