### PR TITLE
added condition for debian 9 default ipv4  interfaces

### DIFF
--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -12,3 +12,5 @@ concat_basedir: "/tmp"
 ipaddress: "172.16.254.254"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
+operatingsystem: "Debian"
+operatingsystemmajrelease: "9"

--- a/templates/debian/default_isc-dhcp-server
+++ b/templates/debian/default_isc-dhcp-server
@@ -8,7 +8,7 @@
 
 # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
 #       Separate multiple interfaces with spaces, e.g. "eth0 eth1".
-<% if @lsbmajdistrelease >= '9' -%>
+<% if @lsbmajdistrelease >= '9' && @lsbdistid == 'Debian' -%>
 INTERFACESv4="<%= Array(@dhcp_interfaces).join(' ') %>"
 <% else -%>
 INTERFACES="<%= Array(@dhcp_interfaces).join(' ') %>"

--- a/templates/debian/default_isc-dhcp-server
+++ b/templates/debian/default_isc-dhcp-server
@@ -8,4 +8,8 @@
 
 # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
 #       Separate multiple interfaces with spaces, e.g. "eth0 eth1".
+<% if @lsbmajdistrelease >= '9' -%>
+INTERFACESv4="<%= Array(@dhcp_interfaces).join(' ') %>"
+<% else -%>
 INTERFACES="<%= Array(@dhcp_interfaces).join(' ') %>"
+<% end -%>

--- a/templates/debian/default_isc-dhcp-server
+++ b/templates/debian/default_isc-dhcp-server
@@ -8,7 +8,7 @@
 
 # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
 #       Separate multiple interfaces with spaces, e.g. "eth0 eth1".
-<% if @lsbmajdistrelease >= '9' && @lsbdistid == 'Debian' -%>
+<% if @operatingsystemmajrelease >= '9' && @operatingsystem == 'Debian' -%>
 INTERFACESv4="<%= Array(@dhcp_interfaces).join(' ') %>"
 <% else -%>
 INTERFACES="<%= Array(@dhcp_interfaces).join(' ') %>"


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

INTERFACES default option deprecated on Debian 9. replaced with basic condition (INTERFACESv4 only)


#### This Pull Request (PR) fixes the following issues

Fixes #177 

