### PR TITLE
Use IPv6 type validation for $nameservers_ipv6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,10 +3,7 @@
 class dhcp (
   Optional[Array[String]] $dnsdomain                      = undef,
   Array[Stdlib::Compat::Ipv4] $nameservers                = [ '8.8.8.8', '8.8.4.4' ],
-  # the ipv6 regex is currently wrong so we can't use it here
-  # https://github.com/puppetlabs/puppetlabs-stdlib/pull/731
-  #Array[Stdlib::Compat::Ipv6] $nameservers_ipv6           = [],
-  Array[String] $nameservers_ipv6                         = [],
+  Array[Stdlib::Compat::Ipv6] $nameservers_ipv6           = [],
   Array[String] $ntpservers                               = [],
   Array[String] $dnssearchdomains                         = [],
   String $dhcp_conf_header                                = 'INTERNAL_TEMPLATE',

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.16.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
The stdlib fix is part of 4.16.0