### PR TITLE
Debian default ipv4 interfaces config has changed

### DIFF
--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -469,9 +469,17 @@ describe 'dhcp', type: :class do
       }
     end
 
-    context 'Debian' do
+    context 'Debian < 9' do
       let :facts do
-        default_facts.merge(operatingsystem: 'Debian', os: { family: 'Debian' })
+        default_facts.merge(
+          os: {
+            name: 'Debian',
+            family: 'Debian',
+            release: {
+              major: '8'
+            }
+          }
+        )
       end
       let :params do
         default_params.merge(interface: 'eth0')
@@ -482,6 +490,29 @@ describe 'dhcp', type: :class do
       it do
         is_expected.to contain_file('/etc/default/isc-dhcp-server'). \
           with_content(%r{INTERFACES=\"eth0\"})
+      end
+    end
+    context 'Debian > 9' do
+      let :facts do
+        default_facts.merge(
+          os: {
+            name: 'Debian',
+            family: 'Debian',
+            release: {
+              major: '9'
+            }
+          }
+        )
+      end
+      let :params do
+        default_params.merge(interface: 'eth0')
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_package('isc-dhcp-server') }
+      it do
+        is_expected.to contain_file('/etc/default/isc-dhcp-server'). \
+          with_content(%r{INTERFACESv4=\"eth0\"})
       end
     end
     context 'Ubuntu' do

--- a/templates/debian/default_isc-dhcp-server
+++ b/templates/debian/default_isc-dhcp-server
@@ -8,4 +8,11 @@
 
 # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
 #       Separate multiple interfaces with spaces, e.g. "eth0 eth1".
-INTERFACES="<%= Array(@dhcp_interfaces).join(' ') %>"
+<%
+  if @facts['os']['name'] == 'Debian' && scope.function_versioncmp([@facts['os']['release']['major'], "9"]) >= 0
+    interfaces_key = 'INTERFACESv4'
+  else
+    interfaces_key = 'INTERFACES'
+  end
+%>
+<%= interfaces_key %>="<%= Array(@dhcp_interfaces).join(' ') %>"


### PR DESCRIPTION
Since stretch, the /etc/defaults/isc-dhcp-server entry for the
interfaces to listen on has changed to INTERFACESv4. This change
reflects that.

Fixes #177 and closes #185