### PR TITLE
make main section nameservers optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ The following is the list of all parameters available for this class.
 | `ldap_server`          | String    | `'localhost'`                     |
 | `ldap_username`        | String    | `'cn=root, dc=example, dc=com'`   |
 | `logfacility`          | String    | `'daemon'`                        |
-| `manage_service`       | Boolean   | `true`                       |
+| `manage_service`       | Boolean   | `true`                            |
 | `max_lease_time`       | Integer   | `86400`                           |
 | `mtu`                  | Integer   | `undef`                           |
-| `nameservers`          | Array     | `[ '8.8.8.8', '8.8.4.4' ]`        |
+| `nameservers`          | Array     | `[]`                              |
 | `nameservers_ipv6`     | Array     | `[]`                              |
 | `ntpservers`           | Array     | `[]`                              |
 | `omapi_algorithm`      | String    | `HMAC-MD5`                        |

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,7 @@
 #
 class dhcp (
   Optional[Array[String]] $dnsdomain                      = undef,
-  Array[Stdlib::Compat::Ipv4] $nameservers                = [ '8.8.8.8', '8.8.4.4' ],
+  Array[Stdlib::Compat::Ipv4] $nameservers                = [],
   Array[Stdlib::Compat::Ipv6] $nameservers_ipv6           = [],
   Array[String] $ntpservers                               = [],
   Array[String] $dnssearchdomains                         = [],


### PR DESCRIPTION
Setting Nameservers in Main Section per Default is not optimal,
In especially in cases where they are set in Pool.
This Request makes Default Nameserver Setting to an optional Setting.
