### PR TITLE
add mac address validation

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -2,7 +2,7 @@
 #
 define dhcp::host (
   Stdlib::Compat::Ip_address $ip,
-  String $mac,
+  Dhcp::Mac $mac,
   String $ddns_hostname = $name,
   Hash $options     = {},
   String $comment   ='',

--- a/spec/type_aliases/mac_spec.rb
+++ b/spec/type_aliases/mac_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'Dhcp::Mac' do
+  it do
+    is_expected.to allow_values(
+      'a:a:a:a:a:a',
+      '00:00:00:00:00:00',
+      '11:11:11:11:11:11',
+      '22:22:22:22:22:22',
+      '33:33:33:33:33:33',
+      '44:44:44:44:44:44',
+      '55:55:55:55:55:55',
+      '66:66:66:66:66:66',
+      '77:77:77:77:77:77',
+      '88:88:88:88:88:88',
+      '99:99:99:99:99:99',
+      'aa:aa:aa:aa:aa:aa',
+      'bb:bb:bb:bb:bb:bb',
+      'cc:cc:cc:cc:cc:cc',
+      'dd:dd:dd:dd:dd:dd',
+      'ee:ee:ee:ee:ee:ee',
+      'ff:ff:ff:ff:ff:ff',
+      'AA:AA:AA:AA:AA:AA',
+      'BB:BB:BB:BB:BB:BB',
+      'CC:CC:CC:CC:CC:CC',
+      'DD:DD:DD:DD:DD:DD',
+      'EE:EE:EE:EE:EE:EE',
+      'FF:FF:FF:FF:FF:FF'
+    )
+  end
+
+  describe 'invalid value handling' do
+    [
+      nil,
+      'aa:aa:aa:aa:aa',
+      'aaa:aa:aa:aa:aa:aa',
+      'aa:aaa:aa:aa:aa:aa',
+      'aa:aa:aaa:aa:aa:aa',
+      'aa:aa:aa:aaa:aa:aa',
+      'aa:aa:aa:aa:aaa:aa',
+      'aa:aa:aa:aa:aa:aaa',
+      'aa:aa:aa:aa:aa:aa:aa',
+      'gg:gg:gg:gg:gg:gg'
+    ].each do |value|
+      it { is_expected.not_to allow_value(value) }
+    end
+  end
+end

--- a/types/mac.pp
+++ b/types/mac.pp
@@ -1,0 +1,1 @@
+type Dhcp::Mac = Pattern[/^[0-9A-Fa-f]{1,2}(:[0-9A-Fa-f]{1,2}){5}$/]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

issue:
validation occurs of IP address in host resource but not mac address. a malformed mac address can break isc dhcp service.

added validation using stdlib::MAC type

#### This Pull Request (PR) fixes the following issues
n/a