### PR TITLE
Purge useless trailing whitespace in template

### DIFF
--- a/templates/dhcpd.conf-extra.erb
+++ b/templates/dhcpd.conf-extra.erb
@@ -1,7 +1,7 @@
 # BEGIN DHCP Extra configurations
 <% unless @extra_config.empty? -%>
 <% @extra_config.each do |config_entry| -%>
-<%= config_entry %>  
+<%= config_entry %>
 <% end -%>
 <% end -%>
 # END DHCP Extra configurations


### PR DESCRIPTION
There are two whitespaces after each dhcp option. This is very confusing
and, depending on your editor config, this results in some warnings
(detected trailing whitespace...).