### PR TITLE
Don't add a newline between each DHCP option

### DIFF
--- a/templates/dhcpd.conf-extra.erb
+++ b/templates/dhcpd.conf-extra.erb
@@ -1,6 +1,6 @@
 # BEGIN DHCP Extra configurations
 <% unless @extra_config.empty? -%>
-<% @extra_config.each do |config_entry| %>
+<% @extra_config.each do |config_entry| -%>
 <%= config_entry %>  
 <% end -%>
 <% end -%>


### PR DESCRIPTION
somebody missed a - in the erb template. This results in a bloated
config file with many empty lines.

