### PR TITLE
Allow host declaration without IP.

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,7 +1,7 @@
 # == Define: dhcp::host
 #
 define dhcp::host (
-  Stdlib::IP::Address $ip,
+  Optional[Stdlib::IP::Address] $ip     = undef,
   Dhcp::Mac $mac,
   String $ddns_hostname                 = $name,
   Hash $options                         = {},

--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -3,7 +3,9 @@ host <%= @host %> {
   # <%= @comment %>
 <% end -%>
   hardware ethernet   <%= @mac.upcase %>;
+<% if @ip -%>
   fixed-address       <%= @ip %>;
+<% end -%>
   ddns-hostname       "<%= @ddns_hostname %>";
 <% if @ignored -%>
   ignore              booting;


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I often use dhcp to allocate hostnames or to distribute other options (eg routers) where I don't care about the IP address. I tried similar code to the above, but (using hiera) I received a message when I did not include an IP address:

`Evaluation Error: Error while evaluating a Resource Statement, Dhcp::Host[LGwebOSTV]: expects a value for parameter 'ip' (file: /etc/puppetlabs/code/environments/production/modules/dhcp/manifests/init.pp, line: 289)`

I have worked around this by setting the IP address to 0.0.0.0 and then ignoring it in the template but this seems like a kludge! 

#### This Pull Request (PR) fixes the following issues
 Fixes #106