### PR TITLE
Add parameter to make installing the package optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The following is the list of all parameters available for this class.
 | `option_code150_value` | String    | `text`                            |
 | `package_provider`     | String    | `$dhcp::params::package_provider` |
 | `packagename`          | String    | `$dhcp::params::packagename`      |
+| `manage_package`       | Boolean   | `true`                            |
 | `pxefilename`          | String    | `undef`                           |
 | `pxeserver`            | String    | `undef`                           |
 | `service_ensure`       | Enum      | `running`                         |

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@ class dhcp (
   $dhcp_dir                                               = $dhcp::params::dhcp_dir,
   String $dhcpd_conf_filename                             = 'dhcpd.conf',
   $packagename                                            = $dhcp::params::packagename,
+  Boolean $manage_package                                 = true,
   $servicename                                            = $dhcp::params::servicename,
   Boolean $manage_service                                 = true,
   $package_provider                                       = $dhcp::params::package_provider,
@@ -147,9 +148,11 @@ class dhcp (
     default => undef,
   }
 
-  package { $packagename:
-    ensure   => installed,
-    provider => $package_provider,
+  if $manage_package {
+    package { $packagename:
+      ensure   => installed,
+      provider => $package_provider,
+    }
   }
 
   file { $dhcp_dir:


### PR DESCRIPTION
#### Pull Request (PR) description
If the `Package[$packagename]` resource is defined in another module,
it breaks with the use of this module. This allows the user to disable
the Package resource in this module.

#### This Pull Request (PR) fixes the following issues
na