### PR TITLE
allow dhcp::host to override default- and max-lease-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,12 @@ Create host reservations.
 May be passed as a hash into the DHCP class.
 ```puppet
 dhcp::host { 'server1':
-  comment => 'Optional descriptive comment',
-  mac     => '00:50:56:00:00:01',
-  ip      => '10.0.1.51',
+  comment            => 'Optional descriptive comment',
+  mac                => '00:50:56:00:00:01',
+  ip                 => '10.0.1.51',
+  # Optionally override subnet/global settings for some hosts.
+  default_lease_time => 600,
+  max_lease_time     => 900
 }
 ```
 

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -3,10 +3,12 @@
 define dhcp::host (
   Stdlib::IP::Address $ip,
   Dhcp::Mac $mac,
-  String $ddns_hostname = $name,
-  Hash $options     = {},
-  String $comment   = '',
-  Boolean $ignored  = false,
+  String $ddns_hostname                 = $name,
+  Hash $options                         = {},
+  String $comment                       = '',
+  Boolean $ignored                      = false,
+  Optional[Integer] $default_lease_time = undef,
+  Optional[Integer] $max_lease_time     = undef,
 ) {
 
   $host = $name

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -62,6 +62,30 @@ describe 'dhcp::host', type: :define do
     end
   end
 
+  context 'when optional parameters defined' do
+    let(:params) do
+      default_params.merge(
+        'default_lease_time' => 600,
+        'max_lease_time'     => 900
+      )
+    end
+
+    it 'creates a host declaration with optional parameters' do
+      content = catalogue.resource('concat::fragment', "dhcp_host_#{title}").send(:parameters)[:content]
+      expected_lines = [
+        "host #{title} {",
+        '  # test_comment',
+        "  hardware ethernet   #{params['mac']};",
+        "  fixed-address       #{params['ip']};",
+        "  ddns-hostname       \"#{title}\";",
+        '  default-lease-time  600;',
+        '  max-lease-time      900;',
+        '}'
+      ]
+      expect(content.split("\n")).to match_array(expected_lines)
+    end
+  end
+
   context 'when ignored defined' do
     let(:params) do
       default_params.merge(

--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -8,6 +8,12 @@ host <%= @host %> {
 <% if @ignored -%>
   ignore              booting;
 <% end -%>
+<% if @default_lease_time -%>
+  default-lease-time  <%= @default_lease_time %>;
+<% end -%>
+<% if @max_lease_time -%>
+  max-lease-time      <%= @max_lease_time %>;
+<% end -%>
 <% if not @options.empty? -%>
 <% @options.keys.sort.each do |option| -%>
   option <%= option %> <%= @options[option] %>;


### PR DESCRIPTION
This can be used where there's a need to have individual hosts vary from
those set for the subnet or globally.

Signed-off-by: John Florian <jflorian@doubledog.org>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

I have use cases where I want certain hosts to have shorter DHCP lease times than those I prefer for global defaults.  The ISC DHCP daemon allows overriding the `max-lease-time` and `default-lease-time` parameters within a host record, now this module can too.  Both of these settings are entirely optional.  If you don't define them, the global (i.e., `dhcpd` class) defaults are used as before and there's no difference in the `dhcpd.hosts` file.

Ideally, this would be extended to `dhcp::pool` as well, because IIRC that too is possible, but I don't have that need.

#### This Pull Request (PR) fixes the following issues
none created
