### PR TITLE
allow dhcp::host to set "on EVENT" handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,20 @@ dhcp::host { 'server1':
   ip                 => '10.0.1.51',
   # Optionally override subnet/global settings for some hosts.
   default_lease_time => 600,
-  max_lease_time     => 900
+  max_lease_time     => 900,
+  # Optionally declare event statements in any combination.
+  on_commit => [
+    'set ClientIP = binary-to-ascii(10, 8, ".", leased-address)',
+    'execute("/usr/local/bin/my_dhcp_helper.sh", ClientIP)'
+  ],
+  on_release => [
+    'set ClientIP = binary-to-ascii(10, 8, ".", leased-address)',
+    'log(concat("Released IP: ", ClientIP))'
+  ],
+  on_expiry => [
+    'set ClientIP = binary-to-ascii(10, 8, ".", leased-address)',
+    'log(concat("Expired IP: ", ClientIP))'
+  ]
 }
 ```
 

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -9,6 +9,9 @@ define dhcp::host (
   Boolean $ignored                      = false,
   Optional[Integer] $default_lease_time = undef,
   Optional[Integer] $max_lease_time     = undef,
+  Array[String[1]] $on_commit           = [],
+  Array[String[1]] $on_release          = [],
+  Array[String[1]] $on_expiry           = [],
 ) {
 
   $host = $name

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -66,7 +66,19 @@ describe 'dhcp::host', type: :define do
     let(:params) do
       default_params.merge(
         'default_lease_time' => 600,
-        'max_lease_time'     => 900
+        'max_lease_time'     => 900,
+        'on_commit' => [
+          'set ClientIP = binary-to-ascii(10, 8, ".", leased-address)',
+          'execute("/usr/local/bin/my_dhcp_helper.sh", ClientIP)'
+        ],
+        'on_release' => [
+          'set ClientIP = binary-to-ascii(10, 8, ".", leased-address)',
+          'log(concat("Released IP: ", ClientIP))'
+        ],
+        'on_expiry' => [
+          'set ClientIP = binary-to-ascii(10, 8, ".", leased-address)',
+          'log(concat("Expired IP: ", ClientIP))'
+        ]
       )
     end
 
@@ -80,6 +92,18 @@ describe 'dhcp::host', type: :define do
         "  ddns-hostname       \"#{title}\";",
         '  default-lease-time  600;',
         '  max-lease-time      900;',
+        '  on commit {',
+        '    set ClientIP = binary-to-ascii(10, 8, ".", leased-address);',
+        '    execute("/usr/local/bin/my_dhcp_helper.sh", ClientIP);',
+        '  }',
+        '  on release {',
+        '    set ClientIP = binary-to-ascii(10, 8, ".", leased-address);',
+        '    log(concat("Released IP: ", ClientIP));',
+        '  }',
+        '  on expiry {',
+        '    set ClientIP = binary-to-ascii(10, 8, ".", leased-address);',
+        '    log(concat("Expired IP: ", ClientIP));',
+        '  }',
         '}'
       ]
       expect(content.split("\n")).to match_array(expected_lines)

--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -19,4 +19,25 @@ host <%= @host %> {
   option <%= option %> <%= @options[option] %>;
 <% end -%>
 <% end -%>
+<% if not @on_commit.empty? -%>
+  on commit {
+<% @on_commit.each do |statement| -%>
+    <%= statement %>;
+<% end -%>
+  }
+<% end -%>
+<% if not @on_release.empty? -%>
+  on release {
+<% @on_release.each do |statement| -%>
+    <%= statement %>;
+<% end -%>
+  }
+<% end -%>
+<% if not @on_expiry.empty? -%>
+  on expiry {
+<% @on_expiry.each do |statement| -%>
+    <%= statement %>;
+<% end -%>
+  }
+<% end -%>
 }


### PR DESCRIPTION
#### Pull Request (PR) description

This adds 3 new optional parameters to `dhcp::host`:

* `on_commit`
* `on_release`
* `on_expiry`

Each of these accepts an array of strings representing statements that dhcpd is to perform when that event occurs for that host.

Signed-off-by: John Florian <jflorian@doubledog.org>

#### This Pull Request (PR) fixes the following issues

none have been created