### PR TITLE
pxeserver (next-server) can be FQDN or IP address

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class dhcp (
   String[1] $ddns_update_static                                    = 'on',
   String[1] $ddns_update_optimize                                  = 'on',
   Enum['allow', 'deny'] $ddns_client_updates                       = 'allow',
-  Optional[Variant[Stdlib::Fqdn,Stdlib::IP::Address]] $pxeserver   = undef,
+  Optional[Stdlib::Host] $pxeserver                                = undef,
   Optional[String[1]] $pxefilename                                 = undef,
   Optional[Integer[1]] $mtu                                        = undef,
   Optional[String[1]] $ipxe_filename                               = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class dhcp (
   String[1] $ddns_update_static                                    = 'on',
   String[1] $ddns_update_optimize                                  = 'on',
   Enum['allow', 'deny'] $ddns_client_updates                       = 'allow',
-  Optional[Stdlib::IP::Address] $pxeserver                         = undef,
+  Optional[Variant[Stdlib::Fqdn,Stdlib::IP::Address]] $pxeserver   = undef,
   Optional[String[1]] $pxefilename                                 = undef,
   Optional[Integer[1]] $mtu                                        = undef,
   Optional[String[1]] $ipxe_filename                               = undef,


### PR DESCRIPTION
#### Pull Request (PR) description

Allow the `parameter` to take FQDN as well as IP address.

#### This Pull Request (PR) fixes the following issues

Fixes #239

