### PR TITLE
add parameters option for hosts

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -1,10 +1,12 @@
 # == Define: dhcp::host
 #
+# @param [Hash] parameters set different parameters like e.g. filename for the host
 define dhcp::host (
   Optional[Stdlib::IP::Address] $ip     = undef,
   Dhcp::Mac $mac,
   String $ddns_hostname                 = $name,
   Hash $options                         = {},
+  Hash $parameters                      = {},
   String $comment                       = '',
   Boolean $ignored                      = false,
   Optional[Integer] $default_lease_time = undef,

--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -21,6 +21,9 @@ host <%= @host %> {
   option <%= option %> <%= @options[option] %>;
 <% end -%>
 <% end -%>
+<% @parameters.keys.sort.each do |param| -%>
+  <%= param %> <%= @parameters[param] %>;
+<% end -%>
 <% if not @on_commit.empty? -%>
   on commit {
 <% @on_commit.each do |statement| -%>


### PR DESCRIPTION
#### Pull Request (PR) description
A parameters option should be added to the host resource. There are some use-cases in which this can be very helpful if you want to overwrite global parameters for a single host. (for instance the filename parameter) This implementation is very flexible. 
Thank you in advance!
