### PR TITLE
Extend support for event clauses to global, pool and pool6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,9 @@ class dhcp (
   Hash[String, Hash] $ignoredsubnets                               = {},
   Hash[String, Hash] $pools                                        = {},
   Hash[String, Hash] $pools6                                       = {},
+  Array[String[1]] $on_commit                                      = [],
+  Array[String[1]] $on_release                                     = [],
+  Array[String[1]] $on_expiry                                      = [],
   Optional[Stdlib::Absolutepath] $dhcpd_binary                     = $dhcp::params::dhcpd_binary
 ) inherits dhcp::params {
   # check if extra_config is a string, if so convert it to an array

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -14,6 +14,10 @@ define dhcp::pool (
   Optional[Integer] $mtu                    = undef,
   String $domain_name                       = '',
   $ignore_unknown                           = undef,
+  Array[String[1]] $on_commit               = [],
+  Array[String[1]] $on_release              = [],
+  Array[String[1]] $on_expiry               = [],
+
 ) {
   include dhcp::params
 

--- a/manifests/pool6.pp
+++ b/manifests/pool6.pp
@@ -14,6 +14,9 @@ define dhcp::pool6 (
   Optional[Integer] $mtu                    = undef,
   String $domain_name                       = '',
   $ignore_unknown                           = undef,
+  Array[String[1]] $on_commit               = [],
+  Array[String[1]] $on_release              = [],
+  Array[String[1]] $on_expiry               = [],
 ) {
   include dhcp::params
 

--- a/templates/dhcpd.conf-header.erb
+++ b/templates/dhcpd.conf-header.erb
@@ -47,4 +47,25 @@ option <%= @globaloptions %>;
 <% if has_variable?( 'mtu' ) && @mtu -%>
 option interface-mtu <%= @mtu %>;
 <% end -%>
+<% if not @on_commit.empty? -%>
+on commit {
+<% @on_commit.each do |statement| -%>
+  <%= statement %>;
+<% end -%>
+}
+<% end -%>
+<% if not @on_release.empty? -%>
+on release {
+<% @on_release.each do |statement| -%>
+  <%= statement %>;
+<% end -%>
+}
+<% end -%>
+<% if not @on_expiry.empty? -%>
+on expiry {
+<% @on_expiry.each do |statement| -%>
+  <%= statement %>;
+<% end -%>
+}
+<% end -%>
 # END DHCP Header

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -59,5 +59,26 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% if @mtu -%>
   option interface-mtu <%= @mtu %>;
 <% end -%>
+<% if not @on_commit.empty? -%>
+  on commit {
+<% @on_commit.each do |statement| -%>
+    <%= statement %>;
+<% end -%>
+  }
+<% end -%>
+<% if not @on_release.empty? -%>
+  on release {
+<% @on_release.each do |statement| -%>
+    <%= statement %>;
+<% end -%>
+  }
+<% end -%>
+<% if not @on_expiry.empty? -%>
+  on expiry {
+<% @on_expiry.each do |statement| -%>
+    <%= statement %>;
+<% end -%>
+  }
+<% end -%>
 }
 

--- a/templates/dhcpd.pool6.erb
+++ b/templates/dhcpd.pool6.erb
@@ -63,5 +63,26 @@ subnet6 <%= @network %>/<%= @prefix %> {
 <% if @mtu -%>
   option interface-mtu <%= @mtu %>;
 <% end -%>
+<% if not @on_commit.empty? -%>
+  on commit {
+<% @on_commit.each do |statement| -%>
+    <%= statement %>;
+<% end -%>
+  }
+<% end -%>
+<% if not @on_release.empty? -%>
+  on release {
+<% @on_release.each do |statement| -%>
+    <%= statement %>;
+<% end -%>
+  }
+<% end -%>
+<% if not @on_expiry.empty? -%>
+  on expiry {
+<% @on_expiry.each do |statement| -%>
+    <%= statement %>;
+<% end -%>
+  }
+<% end -%>
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
The event handlers are currently only supported for dhcp::host (see #216). These handlers can also exist globally in dhcpd.conf or in the pool definition dhcpd::pool and dhcpd::pool6. This PR extends support to these cases


#### This Pull Request (PR) fixes the following issues
Fixes #251
