### PR TITLE
Add support for grouping of dhcp-pools into shared-networks

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,7 @@ class dhcp (
   Hash[String, Hash] $ignoredsubnets                               = {},
   Hash[String, Hash] $pools                                        = {},
   Hash[String, Hash] $pools6                                       = {},
+  Hash[String, Hash] $sharednetworks                               = {},
   Array[String[1]] $on_commit                                      = [],
   Array[String[1]] $on_release                                     = [],
   Array[String[1]] $on_expiry                                      = [],
@@ -308,6 +309,13 @@ class dhcp (
 
   # Setup any DHCP pools for IPv4
   create_resources('dhcp::pool', $pools)
+
+  # Setup any DHCP shared-networks
+  $sharednetworks.each |$sharednetwork, $sharednetworkattr| {
+    dhcp::sharednetwork { $sharednetwork:
+      * => $sharednetworkattr,
+    }
+  }
 
   # check if this is really a bool
   if $use_ldap {

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -8,6 +8,7 @@ define dhcp::pool (
   $failover                                 = '',
   $options                                  = '',
   $parameters                               = '',
+  Optional[String[1]] $sharednetwork        = undef,
   Optional[Array[String]] $nameservers      = undef,
   Optional[Array[String]] $nameservers_ipv6 = undef,
   Optional[String] $pxeserver               = undef,
@@ -26,5 +27,10 @@ define dhcp::pool (
   concat::fragment { "dhcp_pool_${name}":
     target  => "${dhcp_dir}/dhcpd.pools",
     content => template('dhcp/dhcpd.pool.erb'),
+    order   => "10 ${sharednetwork}-10",
+  }
+
+  if $sharednetwork {
+    Dhcp::Sharednetwork[$sharednetwork] -> Concat::Fragment["dhcp_pool_${name}"]
   }
 }

--- a/manifests/pool6.pp
+++ b/manifests/pool6.pp
@@ -8,6 +8,7 @@ define dhcp::pool6 (
   String $failover                          = '',
   String $options                           = '',
   String $parameters                        = '',
+  Optional[String[1]] $sharednetwork        = undef,
   Optional[Array[String]] $nameservers      = undef,
   Optional[Array[String]] $nameservers_ipv6 = undef,
   Optional[String] $pxeserver               = undef,
@@ -25,5 +26,10 @@ define dhcp::pool6 (
   concat::fragment { "dhcp_pool_${name}":
     target  => "${dhcp_dir}/dhcpd.pools",
     content => template('dhcp/dhcpd.pool6.erb'),
+    order   => "10 ${sharednetwork}-10",
+  }
+
+  if $sharednetwork {
+    Dhcp::Sharednetwork[$sharednetwork] -> Concat::Fragment["dhcp_pool_${name}"]
   }
 }

--- a/manifests/sharednetwork.pp
+++ b/manifests/sharednetwork.pp
@@ -1,0 +1,33 @@
+# == Define: dhcp::sharednetwork
+#
+# @summary
+#   defines a sharednetwork-segment to wrap several pools together
+#
+# @param sharednetwork
+#   Name of the sharednetwork as used in `dhcp::pool` and `dhcp::pool6`
+#   defaults to the title of this resource
+#
+# @param parameters
+#   optional defaults you can set for the shared-network
+#   can be either a single parameter-string, or an array of
+#   several parameters
+define dhcp::sharednetwork (
+  String $sharednetwork = $title,
+  Optional[Variant[Array[String[1]], String[1]]] $parameters = undef,
+) {
+  include dhcp::params
+
+  $dhcp_dir = $dhcp::params::dhcp_dir
+
+  concat::fragment {
+    "dhcp_sharednetwork_${name}_head":
+      target  => "${dhcp_dir}/dhcpd.pools",
+      content => template('dhcp/dhcpd.sharednetwork.erb'),
+      order   => "10 ${sharednetwork}-09";
+
+    "dhcp_sharednetwork_${name}_foot":
+      target  => "${dhcp_dir}/dhcpd.pools",
+      content => "}\n",
+      order   => "10 ${sharednetwork}-11";
+  }
+}

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -6,6 +6,8 @@ describe 'dhcp class' do
                   'isc-dhcp-server'
                 when 'RedHat'
                   'dhcpd'
+                when 'Archlinux'
+                  'dhcpd4'
                 end
   context 'minimal parameters' do
     # Using puppet_apply as a helper

--- a/spec/defines/sharednetwork_spec.rb
+++ b/spec/defines/sharednetwork_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe 'dhcp::sharednetwork', type: :define do
+  let :title do
+    'test_sharednetwork'
+  end
+  let(:facts) do
+    {
+      concat_basedir: '/dne',
+      os: {
+        family: 'RedHat',
+        release: { major: '8' }
+      }
+    }
+  end
+  let :default_params do
+    {
+      'sharednetwork' => 'shared1'
+    }
+  end
+
+  context 'creates a shared-network definition' do
+    let(:params) { default_params }
+
+    it { is_expected.to contain_concat__fragment("dhcp_sharednetwork_#{title}_head") }
+    it { is_expected.to contain_concat__fragment("dhcp_sharednetwork_#{title}_foot") }
+  end
+
+  context 'when optional parameters defined' do
+    let(:params) do
+      default_params.merge(
+        'parameters' => [
+          'ddns-updates off',
+          'option routers 1.1.1.1'
+        ]
+      )
+    end
+
+    it 'creates a shared-network declaration with optional parameters' do
+      content = catalogue.resource('concat::fragment', "dhcp_sharednetwork_#{title}_head").send(:parameters)[:content]
+      expected_lines = [
+        '#################################',
+        "# Shared-Network #{title}",
+        '#################################',
+        "shared-network #{title} {",
+        '  ddns-updates off;',
+        '  option routers 1.1.1.1;',
+      ]
+      expect(content.split("\n")).to match_array(expected_lines)
+    end
+  end
+end

--- a/templates/dhcpd.sharednetwork.erb
+++ b/templates/dhcpd.sharednetwork.erb
@@ -1,0 +1,12 @@
+#################################
+# Shared-Network <%= @name %>
+#################################
+shared-network <%= @name %> {
+<% if @parameters.is_a? Array -%>
+<%   @parameters.each do |param| -%>
+  <%= param %>;
+<%   end -%>
+<% elsif @parameters -%>
+  <%= @parameters %>;
+<% end -%>
+


### PR DESCRIPTION
#### Pull Request (PR) description
Enable the grouping of dhcp-pools into shared-networks

#### This Pull Request (PR) fixes the following issues
Fixes #158 
