### PR TITLE
allow to override host-subnetmask for pools

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -1,8 +1,73 @@
 # == Define: dhcp::pool
 #
+# @summary
+#   defines a dhcp-pool for IPv4 networks
+#
+# @param network
+#   Base-IP-Address of the pool
+#
+# @param mask
+#   Networkmask of that pool
+#
+# @param host_mask
+#   Networkmask that is supplied to the client
+#   Defaults to `mask`. Use it to supply a smaller
+#   mask to clients if needed
+#
+# @param gateway
+#   Optional IP-address for the gateway
+#
+# @param range
+#   Optional IP-range to supply addresses from
+#   Specify as String with start- and end-IP-address
+#   separated by space
+#
+# @param failover
+#   Optional name of the DHCP-server to failover
+#
+# @param options
+#   Optional String or Array of `option` to set in the pool
+#
+# @param parameters
+#   Optional String or Array of manual parameters to set
+#
+# @param sharednetwork
+#   Optional String to group this pool into a shared-network
+#   segment by the name `sharednetwork`. You need to define
+#   that segment by using `dhcp::sharednetwork`
+#
+# @param nameservers
+#   Optional set of IPv4-nameservers to supply to the client
+#
+# @param nameservers_ipv6
+#   Optional set of IPv6-nameservers to supply to the client
+#
+# @param pxeserver
+#   Optional name of a PXE-server to boot from
+#
+# @param mtu
+#   Optional size of the MTU to supply to the client
+#
+# @param domain_name
+#   Optional domainname for the client
+#
+# @param ignore_unknown
+#   Set to true to disable leases for clients not
+#   explicitly defined by `dhcp::host`
+#
+# @param on_commit
+#   Set of statements to execute when providing a lease
+#
+# @param on_release
+#   Set of statements to execute when a lease is released
+#
+# @param on_expiry
+#   Set of statements to execute when a lease expires
+#
 define dhcp::pool (
   Stdlib::IP::Address::V4 $network,
   Stdlib::IP::Address::V4 $mask,
+  Stdlib::IP::Address::V4 $host_mask        = $mask,
   $gateway                                  = '',
   $range                                    = '',
   $failover                                 = '',

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -15,10 +15,11 @@ describe 'dhcp::pool', type: :define do
   end
   let :default_params do
     {
-      'gateway'  => '1.1.1.1',
-      'mask'     => '255.255.255.0',
-      'network'  => '1.1.1.0',
-      'range'    => '1.1.1.100 1.1.1.110'
+      'gateway'   => '1.1.1.1',
+      'mask'      => '255.255.255.0',
+      'host_mask' => '255.255.255.128',
+      'network'   => '1.1.1.0',
+      'range'     => '1.1.1.100 1.1.1.110'
     }
   end
 
@@ -58,7 +59,7 @@ describe 'dhcp::pool', type: :define do
         "    range #{params['range']};",
         '  }',
         '',
-        "  option subnet-mask #{params['mask']};",
+        "  option subnet-mask #{params['host_mask']};",
         "  option routers #{params['gateway']};",
         '  on commit {',
         '    set ClientIP = binary-to-ascii(10, 8, ".", leased-address);',

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -25,7 +25,7 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% if @domain_name and !@domain_name.empty? -%>
   option domain-name "<%= @domain_name %>";
 <% end -%>
-  option subnet-mask <%= @mask %>;
+  option subnet-mask <%= @host_mask %>;
 <% if @gateway != '' -%>
   option routers <%= @gateway %>;
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
This patch allows to specify a netmask to single hosts which differs from the global netmask of the pool.

It is useful in an edge case where a big pool is used with lots of ip-telephones where each telephone should be restricted to a `/32` (providing some special optionparameters).

It includes no break-changes, since it only introduces a `host_mask`-parameter which defaults to `mask`-parameter.