### PR TITLE
rename fragments for dhcp6-pools

### DIFF
--- a/manifests/pool6.pp
+++ b/manifests/pool6.pp
@@ -22,7 +22,7 @@ define dhcp::pool6 (
 
   $dhcp_dir = $dhcp::params::dhcp_dir
 
-  concat::fragment { "dhcp_pool_${name}":
+  concat::fragment { "dhcp_pool6_${name}":
     target  => "${dhcp_dir}/dhcpd.pools",
     content => template('dhcp/dhcpd.pool6.erb'),
   }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -6,6 +6,8 @@ describe 'dhcp class' do
                   'isc-dhcp-server'
                 when 'RedHat'
                   'dhcpd'
+                when 'Archlinux'
+                  'dhcpd4'
                 end
   context 'minimal parameters' do
     # Using puppet_apply as a helper

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -180,7 +180,7 @@ describe 'dhcp', type: :class do
 
       it 'has resources' do
         is_expected.to contain_concat__fragment('dhcp_pool_ops.dc1.example.net')
-        is_expected.to contain_concat__fragment('dhcp_pool_ipv6.dc1.example.net')
+        is_expected.to contain_concat__fragment('dhcp_pool6_ipv6.dc1.example.net')
         is_expected.to contain_concat__fragment('dhcp_ignoredsubnet_eth0')
         is_expected.to contain_concat__fragment('dhcp_host_server1')
         is_expected.to contain_concat__fragment('dhcp_class_vendor-class-identifier')

--- a/spec/defines/pool6_spec.rb
+++ b/spec/defines/pool6_spec.rb
@@ -24,7 +24,7 @@ describe 'dhcp::pool6', type: :define do
   context 'creates a pool definition' do
     let(:params) { default_params }
 
-    it { is_expected.to contain_concat__fragment("dhcp_pool_#{title}") }
+    it { is_expected.to contain_concat__fragment("dhcp_pool6_#{title}") }
   end
 
   context 'when optional parameters defined' do
@@ -46,7 +46,7 @@ describe 'dhcp::pool6', type: :define do
     end
 
     it 'creates a pool declaration with optional parameters' do
-      content = catalogue.resource('concat::fragment', "dhcp_pool_#{title}").send(:parameters)[:content]
+      content = catalogue.resource('concat::fragment', "dhcp_pool6_#{title}").send(:parameters)[:content]
       expected_lines = [
         '#################################',
         "# #{title} #{params['network']}/#{params['prefix']}",


### PR DESCRIPTION
#### Pull Request (PR) description
Allow the same resource-title for pool and pool6-definitions

#### This Pull Request (PR) fixes the following issues
Currently you cannot give a dhcp and dhcp6-pool the same resource-title,
since the name would be shared by the concat::fragment. This is quite
unexpected, so make sure that we use a different title on the fragments
for pool6-defines.