### PR TITLE
Bugfix: use correct title in shared-network dependency

### DIFF
--- a/manifests/pool6.pp
+++ b/manifests/pool6.pp
@@ -30,6 +30,6 @@ define dhcp::pool6 (
   }
 
   if $sharednetwork {
-    Dhcp::Sharednetwork[$sharednetwork] -> Concat::Fragment["dhcp_pool_${name}"]
+    Dhcp::Sharednetwork[$sharednetwork] -> Concat::Fragment["dhcp_pool6_${name}"]
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
fixes an issue resulting when PR #261 and #263 were both merged

#### This Pull Request (PR) fixes the following issues
make sure that pool6-definitions with shared-networks use the correct dependency now that PR #263 was merged too.