### PR TITLE
Add CentOS Stream 9 and RHEL 9 support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,11 +165,7 @@ class dhcp (
 
   case $facts['os']['family'] {
     'RedHat': {
-      if $facts['os']['release']['major'] =~ /(7|8)/ {
-        $use_systemd_service_file = true
-      } else {
-        $use_systemd_service_file = false
-      }
+      $use_systemd_service_file = true
     }
     'ArchLinux': {
       $use_systemd_service_file = true
@@ -200,17 +196,6 @@ class dhcp (
           before  => Package[$packagename],
           notify  => $service_notify_real,
           content => template('dhcp/debian/default_isc-dhcp-server'),
-        }
-      }
-      'RedHat': {
-        file { '/etc/sysconfig/dhcpd':
-          ensure  => file,
-          owner   => 'root',
-          group   => 'root',
-          mode    => '0644',
-          before  => Package[$packagename],
-          notify  => $service_notify_real,
-          content => template('dhcp/redhat/sysconfig-dhcpd'),
         }
       }
       /^(FreeBSD|DragonFly)$/: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class dhcp::params {
     }
     'RedHat': {
       $dhcp_dir         = '/etc/dhcp'
-      if $facts['os']['release']['major'] == '8' {
+      if Integer.new($facts['os']['release']['major']) >= 8 {
         $packagename = 'dhcp-server'
       } else {
         $packagename = 'dhcp'

--- a/metadata.json
+++ b/metadata.json
@@ -25,14 +25,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/classes/dhcp_spec.rb
+++ b/spec/classes/dhcp_spec.rb
@@ -24,7 +24,7 @@ describe 'dhcp', type: :class do
         os: {
           family: 'RedHat',
           name: 'RedHat',
-          release: { major: '6' }
+          release: { major: '7' }
         },
         osfamily: 'RedHat',
         operatingsystem: 'RedHat',
@@ -367,7 +367,7 @@ describe 'dhcp', type: :class do
   end
 
   context 'Systemd' do
-    context 'RedHat 7' do
+    context 'RedHat' do
       let :facts do
         {
           os: {
@@ -391,32 +391,6 @@ describe 'dhcp', type: :class do
       it do
         is_expected.to contain_file('/etc/systemd/system/dhcpd.service'). \
           with_content(%r{ExecStart=/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd --no-pid eth0})
-      end
-    end
-
-    context 'RedHat 6' do
-      let :facts do
-        {
-          os: {
-            family: 'RedHat',
-            name: 'RedHat',
-            release: {
-              full: '6',
-              major: '6'
-            }
-          },
-          concat_basedir: '/dne',
-          service_provider: 'systemd'
-        }
-      end
-      let :params do
-        default_params.merge(interface: 'eth0')
-      end
-
-      it { is_expected.to compile.with_all_deps }
-
-      it do
-        is_expected.not_to contain_file('/etc/systemd/system/dhcpd.service')
       end
     end
 

--- a/templates/redhat/sysconfig-dhcpd
+++ b/templates/redhat/sysconfig-dhcpd
@@ -1,2 +1,0 @@
-# Command line options here
-DHCPDARGS=" <%= Array(@dhcp_interfaces).join(' ') %>"


### PR DESCRIPTION
Add support for CentOS Stream 9 and RHEL 9 by doing what the
CentOS 8 support patches should've done to not break on later releases yet again.