### PR TITLE
dhcpd.conf.ddns: allow overriding zone primary nameserver

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,8 @@ class dhcp (
   String[1] $ddns_update_static                                    = 'on',
   String[1] $ddns_update_optimize                                  = 'on',
   Enum['allow', 'deny'] $ddns_client_updates                       = 'allow',
+  Array[Stdlib::IP::Address::V4] $ddns_zone_nameservers            = $nameservers,
+  Array[Stdlib::IP::Address::V6] $ddns_zone_nameservers_ipv6       = $nameservers_ipv6,
   Optional[Stdlib::Host] $pxeserver                                = undef,
   Optional[String[1]] $pxefilename                                 = undef,
   Optional[Integer[1]] $mtu                                        = undef,

--- a/templates/dhcpd.conf.ddns.erb
+++ b/templates/dhcpd.conf.ddns.erb
@@ -14,11 +14,11 @@ use-host-decl-names on;
 include "<%= @dnsupdatekey %>";
 <% @dnsdomain_real.each do |dom| -%>
 zone <%= dom %>. {
-<% if @nameservers && !@nameservers.empty? -%>
-  primary <%= @nameservers.first %>;
+<% if @ddns_zone_nameservers && !@ddns_zone_nameservers.empty? -%>
+  primary <%= @ddns_zone_nameservers.first %>;
 <% end -%>
-<% if @nameservers_ipv6 && !@nameservers_ipv6.empty? -%>
-  primary6 <%= @nameservers_ipv6.first %>;
+<% if @ddns_zone_nameservers_ipv6 && !@ddns_zone_nameservers_ipv6.empty? -%>
+  primary6 <%= @ddns_zone_nameservers_ipv6.first %>;
 <% end -%>
   key <%= @_dnskeyname %>;
 }


### PR DESCRIPTION
Add 2 parameters, ddns_zone_nameservers and ddns_zone_nameservers_ipv6, which defaults to nameservers and nameservers_ipv6, but can be changed for scenarios where the nameserver for DDNS updates is not the same as the nameserver the DHCP server provides to DHCP clients.